### PR TITLE
Content type permissions fix

### DIFF
--- a/BaseballApi/Api/Import/IRemoteFileManager.cs
+++ b/BaseballApi/Api/Import/IRemoteFileManager.cs
@@ -12,4 +12,5 @@ public interface IRemoteFileManager
     public Task<GetObjectResponse> GetFile(RemoteFileDetail fileDetail);
     public Task<GetObjectMetadataResponse> GetFileMetadata(RemoteFileDetail fileDetail);
     public Task<CopyObjectResponse> UpdateFileContentType(RemoteFileDetail fileDetail, string contentType);
+    public string GetPublicUrl(RemoteFileDetail fileDetail);
 }

--- a/BaseballApi/Api/Import/RemoteFileManager.cs
+++ b/BaseballApi/Api/Import/RemoteFileManager.cs
@@ -144,8 +144,15 @@ public class RemoteFileManager : IRemoteFileManager
             DestinationBucket = this.BucketName,
             DestinationKey = key,
             ContentType = contentType,
-            MetadataDirective = S3MetadataDirective.REPLACE
+            MetadataDirective = S3MetadataDirective.REPLACE,
+            CannedACL = S3CannedACL.PublicRead
         };
         return await this.Client.CopyObjectAsync(request);
+    }
+
+    public string GetPublicUrl(RemoteFileDetail fileDetail)
+    {
+        var key = this.GetKey(fileDetail);
+        return $"https://{this.BucketName}.nyc3.digitaloceanspaces.com/{key}";
     }
 }

--- a/BaseballApi/ApiTests/MediaFormatManagerTests.cs
+++ b/BaseballApi/ApiTests/MediaFormatManagerTests.cs
@@ -170,6 +170,8 @@ public class MediaFormatManagerTests : IClassFixture<TestMediaImportDatabaseFixt
             var expectedContentType = expectedContentTypes[file.Id];
             Assert.Equal(expectedContentType, file.ContentType);
             Assert.Equal(expectedContentType, metadata.Headers.ContentType);
+            // Validate that the file is still publicly accessible
+            await RemoteValidator.ValidateFilePublicAccess(new RemoteFileDetail(file));
         }
     }
 

--- a/BaseballApi/ApiTests/RemoteFileValidator.cs
+++ b/BaseballApi/ApiTests/RemoteFileValidator.cs
@@ -16,6 +16,14 @@ public class RemoteFileValidator(IRemoteFileManager fileManager)
         Assert.Equal(expectedContentType, metadata.Headers.ContentType);
     }
 
+    public async Task ValidateFilePublicAccess(RemoteFileDetail fileDetail)
+    {
+        var url = Manager.GetPublicUrl(fileDetail);
+        using var httpClient = new HttpClient();
+        var response = await httpClient.GetAsync(url);
+        Assert.True(response.IsSuccessStatusCode, "Public access to file failed");
+    }
+
     public async Task ValidateFileDeleted(RemoteFileDetail fileDetail)
     {
         try

--- a/media-importer/Media Permissions Fix.ipynb
+++ b/media-importer/Media Permissions Fix.ipynb
@@ -1,0 +1,117 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "3e0381de",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from datetime import date\n",
+    "from tqdm import tqdm\n",
+    "import shutil\n",
+    "import os\n",
+    "\n",
+    "from thumbnails import ThumbnailDef, Thumbnailer, ThumbnailParams\n",
+    "from path_management import PathManager\n",
+    "from bucket_connect import BucketConnector"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "a93b4d21",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "small = ThumbnailDef(120, 'small')\n",
+    "medium = ThumbnailDef(400, 'medium')\n",
+    "large = ThumbnailDef(1600, 'large')\n",
+    "\n",
+    "sizes = [small, large, medium] \n",
+    "thumbnailer = Thumbnailer(sizes)\n",
+    "paths = PathManager(thumbnailer.name_modifiers)\n",
+    "bucket = BucketConnector('./prod.bucket_config', paths)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "039d26a1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "client = bucket.get_client()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "449fa95a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def make_all_objects_public(client, bucket_name):\n",
+    "    \"\"\"\n",
+    "    Iterates through all objects stored one level deep under a GUID\n",
+    "    and applies ACL public-read on each.\n",
+    "    \"\"\"\n",
+    "    paginator = client.get_paginator(\"list_objects_v2\")\n",
+    "\n",
+    "    for page in tqdm(paginator.paginate(Bucket=bucket_name)):\n",
+    "        contents = page.get(\"Contents\", [])\n",
+    "        for obj in tqdm(contents):\n",
+    "            key = obj[\"Key\"]\n",
+    "\n",
+    "            # Optionally skip \"folder\" placeholder objects ending in '/'\n",
+    "            if key.endswith(\"/\"):\n",
+    "                continue\n",
+    "\n",
+    "            client.put_object_acl(\n",
+    "                Bucket=bucket_name,\n",
+    "                Key=key,\n",
+    "                ACL=\"public-read\"\n",
+    "            )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a37f63cc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "make_all_objects_public(client, 'eschenfeldt-baseball-media')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "817abd59",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
No longer set ACL to private when correcting content type on files in media bucket. Includes script to reset permissions on impacted files.