### PR TITLE
Service tracing

### DIFF
--- a/BaseballApi/Api/Observability/Telemetry.cs
+++ b/BaseballApi/Api/Observability/Telemetry.cs
@@ -1,19 +1,39 @@
 using System.Diagnostics;
+using System.Diagnostics.Metrics;
 
 namespace BaseballApi.Observability;
 
 /// <summary>
-/// Shared telemetry primitives for background-job tracing. The <see cref="ActivitySource"/>
-/// is registered with the OpenTelemetry tracer in <c>Program.cs</c> via
-/// <c>AddSource(Telemetry.BackgroundJobsSourceName)</c>; without that registration
+/// Shared telemetry primitives for background-job tracing and metrics. The
+/// <see cref="ActivitySource"/> and <see cref="Meter"/> are registered with the
+/// OpenTelemetry pipeline in <c>Program.cs</c> via
+/// <c>AddSource(Telemetry.BackgroundJobsSourceName)</c> and
+/// <c>AddMeter(Telemetry.MeterName)</c>; without those registrations
 /// <see cref="ActivitySource.StartActivity(string, ActivityKind)"/> returns null, so all
-/// call sites must null-condition the returned activity.
+/// span call sites must null-condition the returned activity.
 /// </summary>
 public static class Telemetry
 {
     public const string BackgroundJobsSourceName = "BaseballApi.BackgroundJobs";
 
     public static readonly ActivitySource BackgroundJobs = new(BackgroundJobsSourceName);
+
+    public const string MeterName = "BaseballApi";
+
+    public static readonly Meter Meter = new(MeterName);
+
+    private static readonly Counter<long> MediaImportOutcomeCounter = Meter.CreateCounter<long>(
+        "media_import.outcomes",
+        unit: "{import}",
+        description: "Media import runs tagged by their final outcome.");
+
+    /// <summary>Final outcome values for the media-import counter and span tag.</summary>
+    public static class MediaImportOutcome
+    {
+        public const string Completed = "completed";
+        public const string Failed = "failed";
+        public const string Skipped = "skipped";
+    }
 
     /// <summary>
     /// Flags a background-job span as failed for an exception, except for cancellation:
@@ -29,5 +49,19 @@ public static class Telemetry
         }
         activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
         activity?.AddException(ex);
+    }
+
+    /// <summary>
+    /// Records a finished media import: increments the outcome counter tagged by
+    /// <paramref name="outcome"/> (use the <see cref="MediaImportOutcome"/> constants) and, when a
+    /// job span is active, annotates it so a trace can be filtered by the same outcome. A
+    /// crash mid-import is intentionally not an outcome here — that surfaces as a span error
+    /// instead. Note the span tag rides on <see cref="Activity.Current"/>, so call this while
+    /// the job's activity is the ambient one.
+    /// </summary>
+    public static void RecordMediaImportOutcome(string outcome)
+    {
+        MediaImportOutcomeCounter.Add(1, new KeyValuePair<string, object?>("status", outcome));
+        Activity.Current?.SetTag("import.outcome", outcome);
     }
 }

--- a/BaseballApi/Api/Observability/Telemetry.cs
+++ b/BaseballApi/Api/Observability/Telemetry.cs
@@ -1,0 +1,17 @@
+using System.Diagnostics;
+
+namespace BaseballApi.Observability;
+
+/// <summary>
+/// Shared telemetry primitives for background-job tracing. The <see cref="ActivitySource"/>
+/// is registered with the OpenTelemetry tracer in <c>Program.cs</c> via
+/// <c>AddSource(Telemetry.BackgroundJobsSourceName)</c>; without that registration
+/// <see cref="ActivitySource.StartActivity(string, ActivityKind)"/> returns null, so all
+/// call sites must null-condition the returned activity.
+/// </summary>
+public static class Telemetry
+{
+    public const string BackgroundJobsSourceName = "BaseballApi.BackgroundJobs";
+
+    public static readonly ActivitySource BackgroundJobs = new(BackgroundJobsSourceName);
+}

--- a/BaseballApi/Api/Observability/Telemetry.cs
+++ b/BaseballApi/Api/Observability/Telemetry.cs
@@ -14,4 +14,20 @@ public static class Telemetry
     public const string BackgroundJobsSourceName = "BaseballApi.BackgroundJobs";
 
     public static readonly ActivitySource BackgroundJobs = new(BackgroundJobsSourceName);
+
+    /// <summary>
+    /// Flags a background-job span as failed for an exception, except for cancellation:
+    /// that's process shutdown rather than a job failure, so recording it would make the
+    /// span-metrics report a spurious error. Null-safe so call sites needn't check the
+    /// (possibly null) activity themselves.
+    /// </summary>
+    public static void RecordJobException(Activity? activity, Exception ex)
+    {
+        if (ex is OperationCanceledException)
+        {
+            return;
+        }
+        activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+        activity?.AddException(ex);
+    }
 }

--- a/BaseballApi/Api/Program.cs
+++ b/BaseballApi/Api/Program.cs
@@ -6,6 +6,7 @@ using BaseballApi.Import;
 using BaseballApi.Services;
 using Microsoft.AspNetCore.Http.Features;
 using BaseballApi.Integrations;
+using BaseballApi.Observability;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
 using OpenTelemetry.Metrics;
@@ -71,6 +72,7 @@ if (!string.IsNullOrWhiteSpace(otelEndpoint))
             })
             .AddHttpClientInstrumentation()
             .AddNpgsql()
+            .AddSource(Telemetry.BackgroundJobsSourceName)
             .AddOtlpExporter())
         .WithMetrics(m => m
             .AddAspNetCoreInstrumentation()

--- a/BaseballApi/Api/Program.cs
+++ b/BaseballApi/Api/Program.cs
@@ -78,6 +78,7 @@ if (!string.IsNullOrWhiteSpace(otelEndpoint))
             .AddAspNetCoreInstrumentation()
             .AddHttpClientInstrumentation()
             .AddRuntimeInstrumentation()
+            .AddMeter(Telemetry.MeterName)
             .AddOtlpExporter());
 
     builder.Logging.AddOpenTelemetry(options =>

--- a/BaseballApi/Api/Services/IMediaImportQueue.cs
+++ b/BaseballApi/Api/Services/IMediaImportQueue.cs
@@ -9,6 +9,10 @@ public interface IMediaImportQueue
     public ValueTask<Guid> PopAsync(CancellationToken cancellationToken);
 
     public bool ImportInProgress { get; }
+
+    /// <summary>Number of imports currently waiting in the queue; surfaced as a gauge metric.</summary>
+    public int Count { get; }
+
     public void MarkImportInProgress();
     public void MarkImportComplete();
 }

--- a/BaseballApi/Api/Services/MediaFormatService.cs
+++ b/BaseballApi/Api/Services/MediaFormatService.cs
@@ -1,4 +1,4 @@
-using System;
+using BaseballApi.Observability;
 
 namespace BaseballApi.Services;
 
@@ -31,26 +31,30 @@ public class MediaFormatService(
 
     private async void SetContentTypes(object? stateInfo)
     {
-        var mediaFormatManager = new MediaFormatManager(MediaImportQueue, ServiceProvider, Logger, CancellationToken);
+        using var activity = Telemetry.BackgroundJobs.StartActivity("job.set-content-types");
         try
         {
+            var mediaFormatManager = new MediaFormatManager(MediaImportQueue, ServiceProvider, Logger, CancellationToken);
             await mediaFormatManager.SetContentTypes();
         }
         catch (Exception ex)
         {
+            Telemetry.RecordJobException(activity, ex);
             Logger.LogError(ex, "Error setting content types.");
         }
     }
 
     private async void CreateAlternateFormats(object? stateInfo)
     {
-        var mediaFormatManager = new MediaFormatManager(MediaImportQueue, ServiceProvider, Logger, CancellationToken);
+        using var activity = Telemetry.BackgroundJobs.StartActivity("job.create-alternate-formats");
         try
         {
+            var mediaFormatManager = new MediaFormatManager(MediaImportQueue, ServiceProvider, Logger, CancellationToken);
             await mediaFormatManager.CreateAlternateFormats();
         }
         catch (Exception ex)
         {
+            Telemetry.RecordJobException(activity, ex);
             Logger.LogError(ex, "Error creating alternate formats.");
         }
     }

--- a/BaseballApi/Api/Services/MediaImportBackgroundService.cs
+++ b/BaseballApi/Api/Services/MediaImportBackgroundService.cs
@@ -34,26 +34,31 @@ public class MediaImportBackgroundService(
                 });
                 Logger.LogInformation("Processing import task.");
 
-                // Create a scope to resolve services
-                using var scope = ServiceProvider.CreateScope();
-                var remoteFileManager = scope.ServiceProvider.GetRequiredService<IRemoteFileManager>();
-                using var context = scope.ServiceProvider.GetRequiredService<BaseballContext>();
-
                 try
                 {
+                    // Create a scope to resolve services
+                    using var scope = ServiceProvider.CreateScope();
+                    var remoteFileManager = scope.ServiceProvider.GetRequiredService<IRemoteFileManager>();
+                    using var context = scope.ServiceProvider.GetRequiredService<BaseballContext>();
+
                     MediaImportQueue.MarkImportInProgress();
-                    // Process the import task
-                    await ProcessImport(importId, remoteFileManager, context, cancellationToken);
+                    try
+                    {
+                        // Process the import task
+                        await ProcessImport(importId, remoteFileManager, context, cancellationToken);
+                    }
+                    finally
+                    {
+                        MediaImportQueue.MarkImportComplete();
+                    }
                 }
-                catch (Exception ex)
+                // Cancellation is shutdown, not a job failure, so let it fall through to
+                // the outer handler without marking the span as errored.
+                catch (Exception ex) when (ex is not OperationCanceledException)
                 {
                     activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
                     activity?.AddException(ex);
                     throw;
-                }
-                finally
-                {
-                    MediaImportQueue.MarkImportComplete();
                 }
             }
             catch (OperationCanceledException)

--- a/BaseballApi/Api/Services/MediaImportBackgroundService.cs
+++ b/BaseballApi/Api/Services/MediaImportBackgroundService.cs
@@ -81,6 +81,7 @@ public class MediaImportBackgroundService(
         if (importTask == null)
         {
             Logger.LogWarning("Import task not found.");
+            Telemetry.RecordMediaImportOutcome(Telemetry.MediaImportOutcome.Skipped);
             return;
         }
 
@@ -88,6 +89,7 @@ public class MediaImportBackgroundService(
             importTask.Status != MediaImportTaskStatus.InProgress)
         {
             Logger.LogWarning("Import task is not in a valid state for processing: {Status}", importTask.Status);
+            Telemetry.RecordMediaImportOutcome(Telemetry.MediaImportOutcome.Skipped);
             return;
         }
 
@@ -123,10 +125,12 @@ public class MediaImportBackgroundService(
         if (errorCount == 0)
         {
             importTask.Status = MediaImportTaskStatus.Completed;
+            Telemetry.RecordMediaImportOutcome(Telemetry.MediaImportOutcome.Completed);
         }
         else
         {
             importTask.Status = MediaImportTaskStatus.Failed;
+            Telemetry.RecordMediaImportOutcome(Telemetry.MediaImportOutcome.Failed);
         }
         importTask.CompletedAt = DateTimeOffset.UtcNow;
         await context.SaveChangesAsync(cancellationToken);

--- a/BaseballApi/Api/Services/MediaImportBackgroundService.cs
+++ b/BaseballApi/Api/Services/MediaImportBackgroundService.cs
@@ -1,6 +1,8 @@
+using System.Diagnostics;
 using BaseballApi.Import;
 using BaseballApi.Media;
 using BaseballApi.Models;
+using BaseballApi.Observability;
 using Microsoft.EntityFrameworkCore;
 
 namespace BaseballApi.Services;
@@ -23,6 +25,9 @@ public class MediaImportBackgroundService(
                 // Wait for an import task to be available
                 var importId = await MediaImportQueue.PopAsync(cancellationToken);
 
+                using var activity = Telemetry.BackgroundJobs.StartActivity("job.media-import");
+                activity?.SetTag("import.id", importId);
+
                 using var logScope = Logger.BeginScope(new Dictionary<string, object>
                 {
                     ["ImportId"] = importId,
@@ -39,6 +44,12 @@ public class MediaImportBackgroundService(
                     MediaImportQueue.MarkImportInProgress();
                     // Process the import task
                     await ProcessImport(importId, remoteFileManager, context, cancellationToken);
+                }
+                catch (Exception ex)
+                {
+                    activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+                    activity?.AddException(ex);
+                    throw;
                 }
                 finally
                 {

--- a/BaseballApi/Api/Services/MediaImportBackgroundService.cs
+++ b/BaseballApi/Api/Services/MediaImportBackgroundService.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using BaseballApi.Import;
 using BaseballApi.Media;
 using BaseballApi.Models;
@@ -52,12 +51,11 @@ public class MediaImportBackgroundService(
                         MediaImportQueue.MarkImportComplete();
                     }
                 }
-                // Cancellation is shutdown, not a job failure, so let it fall through to
-                // the outer handler without marking the span as errored.
-                catch (Exception ex) when (ex is not OperationCanceledException)
+                catch (Exception ex)
                 {
-                    activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
-                    activity?.AddException(ex);
+                    // Records non-cancellation failures on the span; rethrows so the outer
+                    // handler still logs (and a cancellation still breaks the loop).
+                    Telemetry.RecordJobException(activity, ex);
                     throw;
                 }
             }

--- a/BaseballApi/Api/Services/MediaImportQueue.cs
+++ b/BaseballApi/Api/Services/MediaImportQueue.cs
@@ -1,12 +1,28 @@
 using System.Threading.Channels;
+using BaseballApi.Observability;
 
 namespace BaseballApi.Services;
 
-public class MediaImportQueue(ILogger<MediaImportQueue> logger) : IMediaImportQueue
+public class MediaImportQueue : IMediaImportQueue
 {
     private Channel<Guid> Queue { get; } = Channel.CreateUnbounded<Guid>();
-    private ILogger<MediaImportQueue> Logger { get; } = logger;
+    private ILogger<MediaImportQueue> Logger { get; }
     private bool _importInProgress;
+
+    public MediaImportQueue(ILogger<MediaImportQueue> logger)
+    {
+        Logger = logger;
+        // Early-warning signal that the importer is falling behind, read from the unbounded
+        // channel on each metric collection. No need to keep the returned instrument: the
+        // Meter retains it, and observable gauges are pull-based so we never touch it again.
+        Telemetry.Meter.CreateObservableGauge(
+            "media_import.queue.depth",
+            () => Count,
+            unit: "{import}",
+            description: "Media imports waiting in the queue to be processed.");
+    }
+
+    public int Count => Queue.Reader.Count;
 
     public async ValueTask PushAsync(Guid importId)
     {

--- a/BaseballApi/Api/Services/MediaImportTaskRestarter.cs
+++ b/BaseballApi/Api/Services/MediaImportTaskRestarter.cs
@@ -1,5 +1,5 @@
-using System;
 using BaseballApi.Models;
+using BaseballApi.Observability;
 using Microsoft.EntityFrameworkCore;
 
 namespace BaseballApi.Services;
@@ -25,6 +25,7 @@ public class MediaImportTaskRestarter(IMediaImportQueue mediaImportQueue, IServi
 
     private async void RetriggerImports(object? stateInfo)
     {
+        using var activity = Telemetry.BackgroundJobs.StartActivity("job.retrigger-imports");
         try
         {
             Logger.LogInformation("Retriggering abandoned media import tasks...");
@@ -48,6 +49,7 @@ public class MediaImportTaskRestarter(IMediaImportQueue mediaImportQueue, IServi
         }
         catch (Exception ex)
         {
+            Telemetry.RecordJobException(activity, ex);
             Logger.LogError(ex, "An error occurred while retriggering imports.");
         }
     }

--- a/BaseballApi/Api/Services/ReferenceUpdateService.cs
+++ b/BaseballApi/Api/Services/ReferenceUpdateService.cs
@@ -1,4 +1,5 @@
 using BaseballApi.Integrations;
+using BaseballApi.Observability;
 
 namespace BaseballApi.Services;
 
@@ -32,47 +33,53 @@ public class ReferenceUpdateService(
 
     private async void UpdateTeamReferences(object? stateInfo)
     {
-        using var scope = ServiceProvider.CreateScope();
-        var referenceManager = scope.ServiceProvider.GetRequiredService<ReferenceManager>();
+        using var activity = Telemetry.BackgroundJobs.StartActivity("job.update-team-references");
         try
         {
+            using var scope = ServiceProvider.CreateScope();
+            var referenceManager = scope.ServiceProvider.GetRequiredService<ReferenceManager>();
             var updatedCount = await referenceManager.UpdateTeamReferences(CancellationToken);
             Logger.LogInformation("Team reference update completed. {updatedCount} teams updated.", updatedCount);
         }
         catch (Exception ex)
         {
+            Telemetry.RecordJobException(activity, ex);
             Logger.LogError(ex, "Error occurred while updating team references.");
         }
     }
 
     private async void UpdatePlayerReferences(object? stateInfo)
     {
-        using var scope = ServiceProvider.CreateScope();
-        var referenceManager = scope.ServiceProvider.GetRequiredService<ReferenceManager>();
+        using var activity = Telemetry.BackgroundJobs.StartActivity("job.update-player-references");
         try
         {
+            using var scope = ServiceProvider.CreateScope();
+            var referenceManager = scope.ServiceProvider.GetRequiredService<ReferenceManager>();
             var result = await referenceManager.UpdatePlayerReferences(CancellationToken);
             Logger.LogInformation("Player reference update completed. {createdCount} players created, {updatedCount} players updated.",
                 result.CreatedCount, result.UpdatedCount);
         }
         catch (Exception ex)
         {
+            Telemetry.RecordJobException(activity, ex);
             Logger.LogError(ex, "Error occurred while updating player references.");
         }
     }
 
     private async void UpdateFangraphsLinks(object? stateInfo)
     {
-        using var scope = ServiceProvider.CreateScope();
-        var referenceManager = scope.ServiceProvider.GetRequiredService<ReferenceManager>();
+        using var activity = Telemetry.BackgroundJobs.StartActivity("job.update-fangraphs-links");
         try
         {
+            using var scope = ServiceProvider.CreateScope();
+            var referenceManager = scope.ServiceProvider.GetRequiredService<ReferenceManager>();
             var result = await referenceManager.UpdateFangraphsLinks(CancellationToken);
             Logger.LogInformation("Fangraphs link update completed. {playerUpdateCount} players updated, {referencePlayerUpdateCount} reference players updated.",
                 result.PlayersUpdated, result.ReferencePlayersUpdated);
         }
         catch (Exception ex)
         {
+            Telemetry.RecordJobException(activity, ex);
             Logger.LogError(ex, "Error occurred while updating Fangraphs links.");
         }
     }

--- a/BaseballApi/Api/Services/RemoteLogService.cs
+++ b/BaseballApi/Api/Services/RemoteLogService.cs
@@ -1,3 +1,5 @@
+using BaseballApi.Observability;
+
 namespace BaseballApi.Services;
 
 public class RemoteLogService(ILogger<RemoteLogService> logger, IServiceProvider serviceProvider) : BackgroundService
@@ -27,6 +29,7 @@ public class RemoteLogService(ILogger<RemoteLogService> logger, IServiceProvider
 
     private async void UploadLogs(object? stateInfo)
     {
+        using var activity = Telemetry.BackgroundJobs.StartActivity("job.upload-logs");
         try
         {
             // Create a scope to resolve services
@@ -36,12 +39,14 @@ public class RemoteLogService(ILogger<RemoteLogService> logger, IServiceProvider
         }
         catch (Exception ex)
         {
+            Telemetry.RecordJobException(activity, ex);
             Logger.LogError(ex, "Error uploading logs.");
         }
     }
 
     private async void CleanupOldLogs(object? stateInfo)
     {
+        using var activity = Telemetry.BackgroundJobs.StartActivity("job.cleanup-old-logs");
         try
         {
             // Create a scope to resolve services
@@ -51,6 +56,7 @@ public class RemoteLogService(ILogger<RemoteLogService> logger, IServiceProvider
         }
         catch (Exception ex)
         {
+            Telemetry.RecordJobException(activity, ex);
             Logger.LogError(ex, "Error cleaning up old logs.");
         }
     }

--- a/BaseballApi/Api/Services/TempFileCleaner.cs
+++ b/BaseballApi/Api/Services/TempFileCleaner.cs
@@ -97,12 +97,12 @@ public class TempFileCleaner(IServiceProvider serviceProvider, ILogger<TempFileC
                     Logger.LogInformation("Marked resource {ResourceName} as deleted in the database.", resource.BaseName);
                 }
             }
-            Logger.LogInformation("Retriggering of abandoned media import tasks completed.");
+            Logger.LogInformation("Cleanup of temp files completed.");
         }
         catch (Exception ex)
         {
             Telemetry.RecordJobException(activity, ex);
-            Logger.LogError(ex, "An error occurred while retriggering imports.");
+            Logger.LogError(ex, "An error occurred while cleaning up temp files.");
         }
     }
 
@@ -148,6 +148,7 @@ public class TempFileCleaner(IServiceProvider serviceProvider, ILogger<TempFileC
                 }
                 catch (Exception ex)
                 {
+                    Telemetry.RecordJobException(activity, ex);
                     Logger.LogError(ex, "Failed to delete abandoned file: {FileName}", file.FullName);
                 }
             }

--- a/BaseballApi/Api/Services/TempFileCleaner.cs
+++ b/BaseballApi/Api/Services/TempFileCleaner.cs
@@ -1,5 +1,5 @@
-using System;
 using BaseballApi.Models;
+using BaseballApi.Observability;
 using Microsoft.EntityFrameworkCore;
 
 namespace BaseballApi.Services;
@@ -26,6 +26,7 @@ public class TempFileCleaner(IServiceProvider serviceProvider, ILogger<TempFileC
 
     private async void CleanseTempFiles(object? stateInfo)
     {
+        using var activity = Telemetry.BackgroundJobs.StartActivity("job.cleanse-temp-files");
         try
         {
             Logger.LogInformation("Identifying temp files to clean up...");
@@ -100,12 +101,14 @@ public class TempFileCleaner(IServiceProvider serviceProvider, ILogger<TempFileC
         }
         catch (Exception ex)
         {
+            Telemetry.RecordJobException(activity, ex);
             Logger.LogError(ex, "An error occurred while retriggering imports.");
         }
     }
 
     private async void CleanseAbandonedFiles(object? stateInfo)
     {
+        using var activity = Telemetry.BackgroundJobs.StartActivity("job.cleanse-abandoned-files");
         try
         {
             Logger.LogInformation("Identifying abandoned files to clean up...");
@@ -151,6 +154,7 @@ public class TempFileCleaner(IServiceProvider serviceProvider, ILogger<TempFileC
         }
         catch (Exception ex)
         {
+            Telemetry.RecordJobException(activity, ex);
             Logger.LogError(ex, "An error occurred while cleaning up abandoned files.");
         }
     }

--- a/BaseballApi/ApiTests/MetricsTests.cs
+++ b/BaseballApi/ApiTests/MetricsTests.cs
@@ -43,9 +43,9 @@ public class MetricsTests
 
         Telemetry.RecordMediaImportOutcome(Telemetry.MediaImportOutcome.Failed);
 
-        var measurement = Assert.Single(measurements);
-        Assert.Equal(1, measurement.Value);
-        Assert.Equal("failed", measurement.Status);
+        // Contains rather than Single: the counter is static, so a parallel test could record
+        // its own outcome while this listener is active.
+        Assert.Contains(measurements, m => m.Value == 1 && m.Status == "failed");
     }
 
     [Fact]

--- a/BaseballApi/ApiTests/MetricsTests.cs
+++ b/BaseballApi/ApiTests/MetricsTests.cs
@@ -1,0 +1,81 @@
+using System.Diagnostics.Metrics;
+using BaseballApi.Observability;
+using BaseballApi.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace BaseballApiTests;
+
+/// <summary>
+/// Verifies the custom metrics (import-outcome counter + queue-depth gauge) emit through
+/// the shared <see cref="Telemetry.Meter"/>. Like the span tests these use an in-process
+/// listener rather than a real exporter, so they need no collector or database.
+/// </summary>
+public class MetricsTests
+{
+    [Fact]
+    [Trait(TestCategory.Category, TestCategory.Observability)]
+    public void RecordMediaImportOutcome_IncrementsCounterWithStatusTag()
+    {
+        var measurements = new List<(long Value, string? Status)>();
+        using var listener = new MeterListener
+        {
+            InstrumentPublished = (instrument, l) =>
+            {
+                if (instrument.Meter.Name == Telemetry.MeterName && instrument.Name == "media_import.outcomes")
+                {
+                    l.EnableMeasurementEvents(instrument);
+                }
+            },
+        };
+        listener.SetMeasurementEventCallback<long>((_, value, tags, _) =>
+        {
+            string? status = null;
+            foreach (var tag in tags)
+            {
+                if (tag.Key == "status")
+                {
+                    status = tag.Value as string;
+                }
+            }
+            measurements.Add((value, status));
+        });
+        listener.Start();
+
+        Telemetry.RecordMediaImportOutcome(Telemetry.MediaImportOutcome.Failed);
+
+        var measurement = Assert.Single(measurements);
+        Assert.Equal(1, measurement.Value);
+        Assert.Equal("failed", measurement.Status);
+    }
+
+    [Fact]
+    [Trait(TestCategory.Category, TestCategory.Observability)]
+    public async Task QueueDepthGauge_ReportsCurrentQueueCount()
+    {
+        var queue = new MediaImportQueue(NullLogger<MediaImportQueue>.Instance);
+        // Three queued, none popped: a distinctive count so it's not confused with the
+        // (typically empty) queues other test classes may hold alive on the shared meter.
+        await queue.PushAsync(Guid.NewGuid());
+        await queue.PushAsync(Guid.NewGuid());
+        await queue.PushAsync(Guid.NewGuid());
+        Assert.Equal(3, queue.Count);
+
+        var observed = new List<int>();
+        using var listener = new MeterListener
+        {
+            InstrumentPublished = (instrument, l) =>
+            {
+                if (instrument.Meter.Name == Telemetry.MeterName && instrument.Name == "media_import.queue.depth")
+                {
+                    l.EnableMeasurementEvents(instrument);
+                }
+            },
+        };
+        listener.SetMeasurementEventCallback<int>((_, value, _, _) => observed.Add(value));
+        listener.Start();
+
+        listener.RecordObservableInstruments();
+
+        Assert.Contains(3, observed);
+    }
+}

--- a/BaseballApi/ApiTests/TelemetryTests.cs
+++ b/BaseballApi/ApiTests/TelemetryTests.cs
@@ -1,0 +1,90 @@
+using System.Diagnostics;
+using BaseballApi.Observability;
+
+namespace BaseballApiTests;
+
+/// <summary>
+/// Verifies the background-job <see cref="ActivitySource"/> contract that every job
+/// call site relies on. Telemetry exports nothing locally without OTLP secrets, so
+/// these tests attach an in-process <see cref="ActivityListener"/> instead — that is
+/// enough to catch the real wiring failures (wrong source name, missing tags, error
+/// status not recorded) without a collector or a live database.
+/// </summary>
+public class TelemetryTests
+{
+    /// <summary>
+    /// Collects every activity emitted by the background-jobs source for the duration
+    /// of the returned subscription, sampling all spans as the real exporter would.
+    /// </summary>
+    private static ActivityListener ListenToBackgroundJobs(List<Activity> recorded)
+    {
+        var listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == Telemetry.BackgroundJobsSourceName,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
+            ActivityStopped = recorded.Add,
+        };
+        ActivitySource.AddActivityListener(listener);
+        return listener;
+    }
+
+    [Fact]
+    [Trait(TestCategory.Category, TestCategory.Observability)]
+    public void StartActivity_WithListener_EmitsNamedSpanWithTag()
+    {
+        var recorded = new List<Activity>();
+        using var listener = ListenToBackgroundJobs(recorded);
+
+        var importId = Guid.NewGuid();
+        using (var activity = Telemetry.BackgroundJobs.StartActivity("job.media-import"))
+        {
+            // A listener is attached, so the source must produce a live activity; if this
+            // is null the source name is wrong or no listener matched.
+            Assert.NotNull(activity);
+            activity.SetTag("import.id", importId);
+        }
+
+        var span = Assert.Single(recorded);
+        Assert.Equal("job.media-import", span.DisplayName);
+        Assert.Equal(importId, Assert.IsType<Guid>(span.GetTagItem("import.id")));
+        Assert.Equal(ActivityStatusCode.Unset, span.Status);
+    }
+
+    [Fact]
+    [Trait(TestCategory.Category, TestCategory.Observability)]
+    public void RecordException_SetsErrorStatusAndExceptionEvent()
+    {
+        var recorded = new List<Activity>();
+        using var listener = ListenToBackgroundJobs(recorded);
+
+        using (var activity = Telemetry.BackgroundJobs.StartActivity("job.media-import"))
+        {
+            Assert.NotNull(activity);
+            try
+            {
+                throw new InvalidOperationException("boom");
+            }
+            catch (Exception ex)
+            {
+                activity.SetStatus(ActivityStatusCode.Error, ex.Message);
+                activity.AddException(ex);
+            }
+        }
+
+        var span = Assert.Single(recorded);
+        Assert.Equal(ActivityStatusCode.Error, span.Status);
+        Assert.Equal("boom", span.StatusDescription);
+        var exceptionEvent = Assert.Single(span.Events);
+        Assert.Equal("exception", exceptionEvent.Name);
+    }
+
+    [Fact]
+    [Trait(TestCategory.Category, TestCategory.Observability)]
+    public void StartActivity_WithoutListener_ReturnsNull()
+    {
+        // No listener attached: StartActivity must return null, which is why every call
+        // site null-conditions the activity rather than assuming a live span.
+        using var activity = Telemetry.BackgroundJobs.StartActivity("job.media-import");
+        Assert.Null(activity);
+    }
+}

--- a/BaseballApi/ApiTests/TelemetryTests.cs
+++ b/BaseballApi/ApiTests/TelemetryTests.cs
@@ -28,6 +28,10 @@ public class TelemetryTests
         return listener;
     }
 
+    // Unique per call so a test can pick its own span out of the process-global listener,
+    // which could also observe spans from other tests/services running in parallel.
+    private static string UniqueSpanName() => $"job.test-{Guid.NewGuid():N}";
+
     [Fact]
     [Trait(TestCategory.Category, TestCategory.Observability)]
     public void StartActivity_WithListener_EmitsNamedSpanWithTag()
@@ -35,8 +39,9 @@ public class TelemetryTests
         var recorded = new List<Activity>();
         using var listener = ListenToBackgroundJobs(recorded);
 
+        var spanName = UniqueSpanName();
         var importId = Guid.NewGuid();
-        using (var activity = Telemetry.BackgroundJobs.StartActivity("job.media-import"))
+        using (var activity = Telemetry.BackgroundJobs.StartActivity(spanName))
         {
             // A listener is attached, so the source must produce a live activity; if this
             // is null the source name is wrong or no listener matched.
@@ -44,8 +49,7 @@ public class TelemetryTests
             activity.SetTag("import.id", importId);
         }
 
-        var span = Assert.Single(recorded);
-        Assert.Equal("job.media-import", span.DisplayName);
+        var span = Assert.Single(recorded, a => a.DisplayName == spanName);
         Assert.Equal(importId, Assert.IsType<Guid>(span.GetTagItem("import.id")));
         Assert.Equal(ActivityStatusCode.Unset, span.Status);
     }
@@ -57,7 +61,8 @@ public class TelemetryTests
         var recorded = new List<Activity>();
         using var listener = ListenToBackgroundJobs(recorded);
 
-        using (var activity = Telemetry.BackgroundJobs.StartActivity("job.media-import"))
+        var spanName = UniqueSpanName();
+        using (var activity = Telemetry.BackgroundJobs.StartActivity(spanName))
         {
             Assert.NotNull(activity);
             try
@@ -71,7 +76,7 @@ public class TelemetryTests
             }
         }
 
-        var span = Assert.Single(recorded);
+        var span = Assert.Single(recorded, a => a.DisplayName == spanName);
         Assert.Equal(ActivityStatusCode.Error, span.Status);
         Assert.Equal("boom", span.StatusDescription);
         var exceptionEvent = Assert.Single(span.Events);
@@ -85,12 +90,13 @@ public class TelemetryTests
         var recorded = new List<Activity>();
         using var listener = ListenToBackgroundJobs(recorded);
 
-        using (var activity = Telemetry.BackgroundJobs.StartActivity("job.media-import"))
+        var spanName = UniqueSpanName();
+        using (var activity = Telemetry.BackgroundJobs.StartActivity(spanName))
         {
             Telemetry.RecordJobException(activity, new InvalidOperationException("boom"));
         }
 
-        var span = Assert.Single(recorded);
+        var span = Assert.Single(recorded, a => a.DisplayName == spanName);
         Assert.Equal(ActivityStatusCode.Error, span.Status);
         Assert.Equal("boom", span.StatusDescription);
         Assert.Single(span.Events, e => e.Name == "exception");
@@ -105,12 +111,13 @@ public class TelemetryTests
         var recorded = new List<Activity>();
         using var listener = ListenToBackgroundJobs(recorded);
 
-        using (var activity = Telemetry.BackgroundJobs.StartActivity("job.media-import"))
+        var spanName = UniqueSpanName();
+        using (var activity = Telemetry.BackgroundJobs.StartActivity(spanName))
         {
             Telemetry.RecordJobException(activity, new OperationCanceledException());
         }
 
-        var span = Assert.Single(recorded);
+        var span = Assert.Single(recorded, a => a.DisplayName == spanName);
         Assert.Equal(ActivityStatusCode.Unset, span.Status);
         Assert.Empty(span.Events);
     }

--- a/BaseballApi/ApiTests/TelemetryTests.cs
+++ b/BaseballApi/ApiTests/TelemetryTests.cs
@@ -80,6 +80,51 @@ public class TelemetryTests
 
     [Fact]
     [Trait(TestCategory.Category, TestCategory.Observability)]
+    public void RecordJobException_MarksErrorForOrdinaryException()
+    {
+        var recorded = new List<Activity>();
+        using var listener = ListenToBackgroundJobs(recorded);
+
+        using (var activity = Telemetry.BackgroundJobs.StartActivity("job.media-import"))
+        {
+            Telemetry.RecordJobException(activity, new InvalidOperationException("boom"));
+        }
+
+        var span = Assert.Single(recorded);
+        Assert.Equal(ActivityStatusCode.Error, span.Status);
+        Assert.Equal("boom", span.StatusDescription);
+        Assert.Single(span.Events, e => e.Name == "exception");
+    }
+
+    [Fact]
+    [Trait(TestCategory.Category, TestCategory.Observability)]
+    public void RecordJobException_IgnoresCancellation()
+    {
+        // Shutdown cancellation isn't a job failure: the span must stay unset so it
+        // doesn't show up as an error in span-metrics.
+        var recorded = new List<Activity>();
+        using var listener = ListenToBackgroundJobs(recorded);
+
+        using (var activity = Telemetry.BackgroundJobs.StartActivity("job.media-import"))
+        {
+            Telemetry.RecordJobException(activity, new OperationCanceledException());
+        }
+
+        var span = Assert.Single(recorded);
+        Assert.Equal(ActivityStatusCode.Unset, span.Status);
+        Assert.Empty(span.Events);
+    }
+
+    [Fact]
+    [Trait(TestCategory.Category, TestCategory.Observability)]
+    public void RecordJobException_NullActivity_DoesNotThrow()
+    {
+        // No listener => StartActivity returns null; the helper must tolerate it.
+        Telemetry.RecordJobException(null, new InvalidOperationException("boom"));
+    }
+
+    [Fact]
+    [Trait(TestCategory.Category, TestCategory.Observability)]
     public void StartActivity_WithoutListener_ReturnsNull()
     {
         // No listener attached: StartActivity must return null, which is why every call

--- a/BaseballApi/ApiTests/TestCategory.cs
+++ b/BaseballApi/ApiTests/TestCategory.cs
@@ -9,4 +9,5 @@ public class TestCategory
 
     // Category names
     public const string Media = "Media";
+    public const string Observability = "Observability";
 }


### PR DESCRIPTION
Trace background jobs via `Activity`, and add two media import metrics: import counts by outcome and current queue depth.