### PR TITLE
Expanded host information

### DIFF
--- a/.github/ci/otel-resource-attributes.sh
+++ b/.github/ci/otel-resource-attributes.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env sh
+#
+# Emit the OpenTelemetry resource attributes describing the host this runs on, as
+# a comma-separated OTEL_RESOURCE_ATTRIBUTES value on stdout.
+#
+# Prod runs on a DigitalOcean droplet; this mirrors the collector
+# resourcedetectionprocessor's "digitalocean" detector by reading the droplet
+# metadata service (link-local 169.254.169.254, served by the hypervisor) and
+# emitting cloud.provider / cloud.region / host.id / host.name. We also set
+# grafana.host.id (= droplet id): Grafana Cloud associates telemetry with a host
+# via grafana.host.id (and host.name + cloud.provider); plain host.id is ignored
+# by Grafana but kept to match OTel conventions.
+#
+# If the metadata service is unavailable (any field empty), fall back to the
+# systemd machine id so host info still resolves rather than emitting a partial
+# or empty attribute set. Keeping this logic here keeps the app and compose.yaml
+# cloud-agnostic — "digitalocean" appears only in this script.
+#
+# Used by deploy.yml (on the droplet, after git pull) and exercised by
+# cd-health.yml (piped over SSH to the live droplet on every PR to main), so the
+# metadata calls and fallback are validated before a real deploy.
+set -eu
+
+META="http://169.254.169.254/metadata/v1"
+
+# -f drops the body on HTTP errors (so an error page can't become an attribute
+# value); -sS stays quiet but still reports real failures; the tight timeouts
+# keep a metadata hiccup from stalling the deploy; tr strips any trailing newline.
+meta() { curl -fsS --connect-timeout 2 --max-time 5 "$1" | tr -d '\n'; }
+
+id="$(meta "$META/id" || true)"
+region="$(meta "$META/region" || true)"
+name="$(meta "$META/hostname" || true)"
+
+if [ -n "$id" ] && [ -n "$region" ] && [ -n "$name" ]; then
+    printf 'cloud.provider=digitalocean,cloud.region=%s,host.id=%s,host.name=%s,grafana.host.id=%s' \
+        "$region" "$id" "$name" "$id"
+else
+    id="$(cat /etc/machine-id)"
+    printf 'host.name=%s,host.id=%s,grafana.host.id=%s' "$(hostname)" "$id" "$id"
+fi

--- a/.github/ci/otel-resource-attributes.sh
+++ b/.github/ci/otel-resource-attributes.sh
@@ -30,12 +30,12 @@ meta() { curl -fsS --connect-timeout 2 --max-time 5 "$1" | tr -d '\n'; }
 
 id="$(meta "$META/id" || true)"
 region="$(meta "$META/region" || true)"
-name="$(meta "$META/hostname" || true)"
+name="$(meta "$META/hostnamex" || true)"
 
 if [ -n "$id" ] && [ -n "$region" ] && [ -n "$name" ]; then
     printf 'cloud.provider=digitalocean,cloud.region=%s,host.id=%s,host.name=%s,grafana.host.id=%s' \
         "$region" "$id" "$name" "$id"
 else
-    id="$(cat /etc/machine-id)"
+    id="$(tr -d '\n' < /etc/machine-id)"
     printf 'host.name=%s,host.id=%s,grafana.host.id=%s' "$(hostname)" "$id" "$id"
 fi

--- a/.github/ci/otel-resource-attributes.sh
+++ b/.github/ci/otel-resource-attributes.sh
@@ -30,7 +30,7 @@ meta() { curl -fsS --connect-timeout 2 --max-time 5 "$1" | tr -d '\n'; }
 
 id="$(meta "$META/id" || true)"
 region="$(meta "$META/region" || true)"
-name="$(meta "$META/hostnamex" || true)"
+name="$(meta "$META/hostname" || true)"
 
 if [ -n "$id" ] && [ -n "$region" ] && [ -n "$name" ]; then
     printf 'cloud.provider=digitalocean,cloud.region=%s,host.id=%s,host.name=%s,grafana.host.id=%s' \

--- a/.github/ci/server-health.sh
+++ b/.github/ci/server-health.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env sh
+#
+# Read-only health check of the deploy target, run over SSH by cd-health.yml to
+# validate the CD path before a real deploy: confirms the SSH login, that docker
+# compose is available, the repo checkout's state, and that the production app
+# settings file is present (its absence would fail the image build during deploy).
+#
+# Piped to the droplet over stdin (ssh ... 'sh -s' < this), so the version that
+# runs is the PR's copy, not whatever is currently deployed.
+set -eu
+
+echo "Logged in as:   $(whoami)"
+echo "docker compose: $(docker compose version --short)"
+cd ~/source/baseball-stats
+echo "Repo HEAD:      $(git rev-parse --short HEAD) on $(git rev-parse --abbrev-ref HEAD)"
+git status --short --branch
+if [ -f BaseballApi/appsettings.Production.json ]; then
+    echo "prod config:    present"
+else
+    echo "prod config:    MISSING — BaseballApi/appsettings.Production.json (build would fail)"
+    exit 1
+fi

--- a/.github/workflows/cd-health.yml
+++ b/.github/workflows/cd-health.yml
@@ -9,7 +9,8 @@ on:
     branches: [main]
 
 permissions:
-  id-token: write # Tailscale OIDC 
+  id-token: write # Tailscale OIDC
+  contents: read # actions/checkout (explicit since setting any scope zeroes the rest)
 
 jobs:
   cd-health:

--- a/.github/workflows/cd-health.yml
+++ b/.github/workflows/cd-health.yml
@@ -16,6 +16,9 @@ jobs:
     name: CD Health
     runs-on: ubuntu-latest
     steps:
+      # Needed so the .github/ci scripts below exist on the runner to pipe over SSH.
+      - uses: actions/checkout@v6
+
       - name: Connect to tailnet
         uses: tailscale/github-action@v4
         with:
@@ -27,21 +30,29 @@ jobs:
         env:
           DEPLOY_HOST: ${{ vars.DEPLOY_SSH_HOST }}
           DEPLOY_USER: ${{ vars.DEPLOY_SSH_USER }}
+        # Pipe the PR's copy of the script over stdin so it runs regardless of the
+        # droplet's deployed checkout — this is the same mechanism deploy.yml relies
+        # on for the OTel script, exercised here before any deploy.
         run: |
-          ssh -o StrictHostKeyChecking=accept-new "$DEPLOY_USER@$DEPLOY_HOST" '
-            set -e
-            echo "Logged in as:  $(whoami)"
-            echo "docker compose: $(docker compose version --short)"
-            cd ~/source/baseball-stats
-            echo "Repo HEAD:     $(git rev-parse --short HEAD) on $(git rev-parse --abbrev-ref HEAD)"
-            git status --short --branch
-            if [ -f BaseballApi/appsettings.Production.json ]; then
-              echo "prod config:   present"
-            else
-              echo "prod config:   MISSING — BaseballApi/appsettings.Production.json (build would fail)"
-              exit 1
-            fi
-          '
+          ssh -o StrictHostKeyChecking=accept-new "$DEPLOY_USER@$DEPLOY_HOST" 'sh -s' \
+            < .github/ci/server-health.sh
+
+      - name: OTel resource attributes (live droplet)
+        env:
+          DEPLOY_HOST: ${{ vars.DEPLOY_SSH_HOST }}
+          DEPLOY_USER: ${{ vars.DEPLOY_SSH_USER }}
+        # Run the exact script deploy.yml uses against the real droplet and show the
+        # OTEL_RESOURCE_ATTRIBUTES it will produce, so metadata access + fallback are
+        # confirmed before merge. Fail if grafana.host.id (the Grafana host id) is
+        # missing or empty.
+        run: |
+          attrs="$(ssh -o StrictHostKeyChecking=accept-new "$DEPLOY_USER@$DEPLOY_HOST" 'sh -s' \
+            < .github/ci/otel-resource-attributes.sh)"
+          echo "OTEL_RESOURCE_ATTRIBUTES=$attrs"
+          case "$attrs" in
+            *grafana.host.id=?*) ;;
+            *) echo "::error::otel-resource-attributes.sh produced no grafana.host.id" >&2; exit 1 ;;
+          esac
 
       - name: Read-only DB access (migration-gate creds)
         env:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,14 +42,11 @@ jobs:
             cd ~/source/baseball-stats
             git pull --ff-only
             export GIT_SHA="$(git rev-parse --short HEAD)"
-            # Detect the DigitalOcean droplet from its metadata service (this runs
-            # ON the droplet) and assemble the OTel resource attributes here, so the
-            # app and compose.yaml stay cloud-agnostic. Grafana Cloud associates
-            # telemetry with a host via grafana.host.id (and host.name+cloud.provider);
-            # plain host.id is ignored by Grafana but kept to match OTel conventions.
-            META=http://169.254.169.254/metadata/v1
-            DROPLET_ID="$(curl -s --max-time 5 "$META/id")"
-            export OTEL_RESOURCE_ATTRIBUTES="cloud.provider=digitalocean,cloud.region=$(curl -s --max-time 5 "$META/region"),host.id=${DROPLET_ID},host.name=$(curl -s --max-time 5 "$META/hostname"),grafana.host.id=${DROPLET_ID}"
+            # Host/cloud resource attributes for telemetry, assembled from the
+            # DigitalOcean metadata service by the just-pulled script (kept out of
+            # this workflow so the logic is testable and the file stays lean; its
+            # behaviour is validated against the live droplet by cd-health.yml).
+            export OTEL_RESOURCE_ATTRIBUTES="$(sh .github/ci/otel-resource-attributes.sh)"
             docker compose --profile prod down
             docker compose --profile prod up -d --build
             docker image prune -f

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,7 +42,14 @@ jobs:
             cd ~/source/baseball-stats
             git pull --ff-only
             export GIT_SHA="$(git rev-parse --short HEAD)"
-            export HOST_NAME="$(hostname)" HOST_ID="$(cat /etc/machine-id)"
+            # Detect the DigitalOcean droplet from its metadata service (this runs
+            # ON the droplet) and assemble the OTel resource attributes here, so the
+            # app and compose.yaml stay cloud-agnostic. Grafana Cloud associates
+            # telemetry with a host via grafana.host.id (and host.name+cloud.provider);
+            # plain host.id is ignored by Grafana but kept to match OTel conventions.
+            META=http://169.254.169.254/metadata/v1
+            DROPLET_ID="$(curl -s --max-time 5 "$META/id")"
+            export OTEL_RESOURCE_ATTRIBUTES="cloud.provider=digitalocean,cloud.region=$(curl -s --max-time 5 "$META/region"),host.id=${DROPLET_ID},host.name=$(curl -s --max-time 5 "$META/hostname"),grafana.host.id=${DROPLET_ID}"
             docker compose --profile prod down
             docker compose --profile prod up -d --build
             docker image prune -f

--- a/README.md
+++ b/README.md
@@ -62,3 +62,12 @@ The flat `OTEL_*` keys are read by the OTLP exporter directly from
   Configure** page (it differs from the Prometheus/Loki/Tempo instance IDs)
   and the token is a Cloud Access Policy token with `metrics:write`,
   `logs:write`, and `traces:write` scopes.
+
+Host/cloud resource attributes are not in this config. `deploy.yml` reads the
+DigitalOcean droplet's [metadata service](https://docs.digitalocean.com/reference/api/metadata/)
+(`http://169.254.169.254/metadata/v1`) on the box and assembles
+`OTEL_RESOURCE_ATTRIBUTES` (`cloud.provider`, `cloud.region`, `host.id`,
+`host.name`, `grafana.host.id`), which the SDK merges into the resource. This
+keeps the app and `compose.yaml` cloud-agnostic. Grafana Cloud associates
+telemetry with a host via `grafana.host.id` (and `host.name` + `cloud.provider`);
+plain `host.id` is ignored by Grafana but kept to match OTel conventions.

--- a/README.md
+++ b/README.md
@@ -70,4 +70,6 @@ DigitalOcean droplet's [metadata service](https://docs.digitalocean.com/referenc
 `host.name`, `grafana.host.id`), which the SDK merges into the resource. This
 keeps the app and `compose.yaml` cloud-agnostic. Grafana Cloud associates
 telemetry with a host via `grafana.host.id` (and `host.name` + `cloud.provider`);
-plain `host.id` is ignored by Grafana but kept to match OTel conventions.
+plain `host.id` is ignored by Grafana but kept to match OTel conventions. If the
+metadata service is unavailable, deploy falls back to the systemd machine id and
+emits only `host.name`/`host.id`/`grafana.host.id` (no `cloud.*`).

--- a/compose.yaml
+++ b/compose.yaml
@@ -46,10 +46,11 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
-      # Identify the underlying host (not the ephemeral container) for telemetry.
-      # Values are exported from the real VM by deploy.yml; the OTel SDK merges
-      # OTEL_RESOURCE_ATTRIBUTES into the resource automatically.
-      - OTEL_RESOURCE_ATTRIBUTES=host.name=${HOST_NAME},host.id=${HOST_ID}
+      # Host/cloud resource attributes are derived from the VM metadata
+      # service and assembled into OTEL_RESOURCE_ATTRIBUTES by deploy.yml; the OTel
+      # SDK merges that env var into the resource automatically. Kept as a pass-through
+      # so this file stays cloud-agnostic.
+      - OTEL_RESOURCE_ATTRIBUTES
     cpus: '0.7'
     mem_limit: 2G
     mem_reservation: 128M


### PR DESCRIPTION
Use DigitalOcean metadata endpoint in deploy.yml to construct a more detailed OTEL_RESOURCE_ATTRIBUTES string that satisfies Grafana Cloud's priority system in two different ways. Main application code remains cloud-agnostic by accepting the full set of attributes from the deploy process.

Fixes #141 