### PR TITLE
Avoid Docker env override

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,7 +46,11 @@ jobs:
             # DigitalOcean metadata service by the just-pulled script (kept out of
             # this workflow so the logic is testable and the file stays lean; its
             # behaviour is validated against the live droplet by cd-health.yml).
-            export OTEL_RESOURCE_ATTRIBUTES="$(sh .github/ci/otel-resource-attributes.sh)"
+            # Carried in HOST_RESOURCE_ATTRS, not OTEL_RESOURCE_ATTRIBUTES, because
+            # the docker CLI overrides the latter with its own telemetry value
+            # (docker.cli.cobra.command_path=...) before compose forwards it into
+            # the container; compose maps HOST_RESOURCE_ATTRS back in. See docker/cli#4958.
+            export HOST_RESOURCE_ATTRS="$(sh .github/ci/otel-resource-attributes.sh)"
             docker compose --profile prod down
             docker compose --profile prod up -d --build
             docker image prune -f

--- a/compose.yaml
+++ b/compose.yaml
@@ -46,11 +46,15 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
-      # Host/cloud resource attributes are derived from the VM metadata
-      # service and assembled into OTEL_RESOURCE_ATTRIBUTES by deploy.yml; the OTel
-      # SDK merges that env var into the resource automatically. Kept as a pass-through
-      # so this file stays cloud-agnostic.
-      - OTEL_RESOURCE_ATTRIBUTES
+      # Host/cloud resource attributes are derived from the VM metadata service by
+      # deploy.yml; the OTel SDK merges OTEL_RESOURCE_ATTRIBUTES into the resource.
+      # NOTE: do NOT change this to a bare `- OTEL_RESOURCE_ATTRIBUTES` pass-through.
+      # The docker CLI overrides OTEL_RESOURCE_ATTRIBUTES in its own environment with
+      # its telemetry value (docker.cli.cobra.command_path=...), so a pass-through
+      # forwards Docker's value into the container, not ours. deploy.yml carries the
+      # value in HOST_RESOURCE_ATTRS (which Docker leaves alone) and we map it back
+      # in here. See docker/cli#4958.
+      - OTEL_RESOURCE_ATTRIBUTES=${HOST_RESOURCE_ATTRS}
     cpus: '0.7'
     mem_limit: 2G
     mem_reservation: 128M


### PR DESCRIPTION
Don't use OTEL_RESOURCE_ATTRIBUTES to pass that value into docker because the docker cli sets its own value