### PR TITLE
MLBAM Reference Metrics

### DIFF
--- a/BaseballApi/Api/Integrations/ReferenceManager.cs
+++ b/BaseballApi/Api/Integrations/ReferenceManager.cs
@@ -1,14 +1,17 @@
+using System.Diagnostics;
 using BaseballApi.Models;
+using BaseballApi.Observability;
 using Microsoft.EntityFrameworkCore;
 
 namespace BaseballApi.Integrations;
 
-public class ReferenceManager(ILogger<ReferenceManager> logger, BaseballContext context, IMLBAMConnector mlbamConnector, FangraphsConnector fangraphsConnector)
+public class ReferenceManager(ILogger<ReferenceManager> logger, BaseballContext context, IMLBAMConnector mlbamConnector, FangraphsConnector fangraphsConnector, ReferenceUpdateMetrics metrics)
 {
     private ILogger<ReferenceManager> Logger { get; } = logger;
     private IMLBAMConnector MLBAMConnector { get; } = mlbamConnector;
     private BaseballContext Context { get; } = context;
     private FangraphsConnector FangraphsConnector { get; } = fangraphsConnector;
+    private ReferenceUpdateMetrics Metrics { get; } = metrics;
 
     public async Task<int> UpdateTeamReferences(CancellationToken cancellation)
     {
@@ -39,6 +42,15 @@ public class ReferenceManager(ILogger<ReferenceManager> logger, BaseballContext 
         var mlbamCurrentPlayers = await MLBAMConnector.GetPlayersAsync(cancellation);
         int createdCount = 0;
         int updatedCount = 0;
+        // Per-run disposition of each feed player, plus the colliding Players for each
+        // ambiguous name, so we can both count outcomes and surface the fixable rows at the end.
+        var outcomeCounts = new Dictionary<string, int>();
+        var ambiguousByName = new Dictionary<string, List<Player>>();
+        void RecordOutcome(string outcome)
+        {
+            Metrics.RecordPlayerMatchOutcome(outcome);
+            outcomeCounts[outcome] = outcomeCounts.GetValueOrDefault(outcome) + 1;
+        }
         Logger.LogInformation("Fetched {count} current players from MLBAM.", mlbamCurrentPlayers.People.Count);
         foreach (var mlbamPlayer in mlbamCurrentPlayers.People)
         {
@@ -65,7 +77,13 @@ public class ReferenceManager(ILogger<ReferenceManager> logger, BaseballContext 
                     Logger.LogInformation("Created ReferencePlayer for {player} with MLBAMId {mlbamId}.", mlbamPlayer.FullName, mlbamPlayer.Id);
                 }
             }
-            if (referencePlayer != null)
+            if (referencePlayer == null)
+            {
+                // No MLBAMId match and no birthdate to match or create on: nothing we can do
+                // this run. Previously a silent fall-through; now counted explicitly.
+                RecordOutcome(ReferenceUpdateMetrics.PlayerMatchOutcome.DroppedNoBirthdate);
+            }
+            else
             {
                 var updated = false;
                 if (referencePlayer.MLBAMId != mlbamPlayer.Id)
@@ -100,13 +118,18 @@ public class ReferenceManager(ILogger<ReferenceManager> logger, BaseballContext 
                     referencePlayer.CurrentTeamId = team.Id;
                     updated = true;
                 }
-                var player = MatchPlayerByMLBAMPlayer(referencePlayer, mlbamPlayer);
-                if (player != null && referencePlayer.PlayerId != player.Id)
+                var match = MatchPlayerByMLBAMPlayer(referencePlayer, mlbamPlayer);
+                RecordOutcome(match.Outcome);
+                if (match.Outcome == ReferenceUpdateMetrics.PlayerMatchOutcome.Ambiguous && match.AmbiguousPlayers != null)
+                {
+                    ambiguousByName[mlbamPlayer.FullName.ToLowerInvariant()] = match.AmbiguousPlayers;
+                }
+                if (match.Player != null && referencePlayer.PlayerId != match.Player.Id)
                 {
                     Logger.LogInformation("Linking ReferencePlayer {referencePlayer} to Player {player} (id {playerId}): previously {oldPlayer} (id {oldPlayerId}).",
-                        referencePlayer.Name, player.Name, player.Id,
+                        referencePlayer.Name, match.Player.Name, match.Player.Id,
                         referencePlayer.Player?.Name ?? "none", referencePlayer.PlayerId);
-                    referencePlayer.Player = player;
+                    referencePlayer.Player = match.Player;
                     updated = true;
                 }
                 if (updated && !isNewlyCreated)
@@ -126,6 +149,8 @@ public class ReferenceManager(ILogger<ReferenceManager> logger, BaseballContext 
         Logger.LogInformation("Completed player reference update: {createdCount} players created, {updatedCount} players updated.",
             createdCount, updatedCount);
 
+        await RecordPlayerMatchState(outcomeCounts, ambiguousByName, cancellation);
+
         // when we have more integrations they can also be handled here
         // unless they require too many api calls
 
@@ -135,6 +160,91 @@ public class ReferenceManager(ILogger<ReferenceManager> logger, BaseballContext 
             UpdatedCount = updatedCount
         };
     }
+
+    /// <summary>
+    /// Cap on how many ambiguous name groups / unmatched Players we spell out individually in the
+    /// end-of-run logs; counts are always reported in full, only the row-level detail is sampled.
+    /// </summary>
+    private const int MaxAmbiguousGroupsLogged = 50;
+    private const int MaxUnmatchedSampleLogged = 25;
+
+    /// <summary>
+    /// Captures the post-run match state for the observability gauges and surfaces the actual
+    /// fixable rows (ambiguous name groups) plus a sample of unmatched Players in the logs. The DB
+    /// counts are queried fresh rather than derived from the loop so they reflect total state, not
+    /// just this run's feed.
+    /// </summary>
+    private async Task RecordPlayerMatchState(
+        IReadOnlyDictionary<string, int> outcomeCounts,
+        IReadOnlyDictionary<string, List<Player>> ambiguousByName,
+        CancellationToken cancellation)
+    {
+        var totalPlayers = await Context.Players.CountAsync(cancellation);
+        var matchedPlayers = await Context.Players
+            .CountAsync(p => Context.ReferencePlayers.Any(rp => rp.PlayerId == p.Id), cancellation);
+        var unmatchedPlayers = totalPlayers - matchedPlayers;
+        var ambiguousGroups = ambiguousByName.Count;
+        var fixableUnmatched = ambiguousByName.Values
+            .SelectMany(players => players)
+            .Select(p => p.Id)
+            .Distinct()
+            .Count();
+
+        Metrics.UpdatePlayerStateSnapshot(new ReferenceUpdateMetrics.PlayerStateSnapshot(
+            Matched: matchedPlayers,
+            Unmatched: unmatchedPlayers,
+            AmbiguousNameGroups: ambiguousGroups,
+            FixableUnmatched: fixableUnmatched));
+
+        var activity = Activity.Current;
+        if (activity != null)
+        {
+            foreach (var (outcome, count) in outcomeCounts)
+            {
+                activity.SetTag($"match.{outcome}", count);
+            }
+            activity.SetTag("match.players_total", totalPlayers);
+            activity.SetTag("match.players_matched", matchedPlayers);
+            activity.SetTag("match.players_unmatched", unmatchedPlayers);
+            activity.SetTag("match.ambiguous_name_groups", ambiguousGroups);
+        }
+
+        Logger.LogInformation(
+            "Player match summary: {linkedByNameAndDob} linked by name+DOB, {linkedByNameOnly} by name only, {ambiguous} ambiguous, {unmatched} unmatched, {droppedNoBirthdate} dropped (no birthdate). DB state: {matchedPlayers}/{totalPlayers} Players matched, {unmatchedPlayers} unmatched, {fixableUnmatched} fixable across {ambiguousGroups} ambiguous name groups.",
+            outcomeCounts.GetValueOrDefault(ReferenceUpdateMetrics.PlayerMatchOutcome.LinkedByNameAndDob),
+            outcomeCounts.GetValueOrDefault(ReferenceUpdateMetrics.PlayerMatchOutcome.LinkedByNameOnly),
+            outcomeCounts.GetValueOrDefault(ReferenceUpdateMetrics.PlayerMatchOutcome.Ambiguous),
+            outcomeCounts.GetValueOrDefault(ReferenceUpdateMetrics.PlayerMatchOutcome.Unmatched),
+            outcomeCounts.GetValueOrDefault(ReferenceUpdateMetrics.PlayerMatchOutcome.DroppedNoBirthdate),
+            matchedPlayers, totalPlayers, unmatchedPlayers, fixableUnmatched, ambiguousGroups);
+
+        foreach (var (name, players) in ambiguousByName.Take(MaxAmbiguousGroupsLogged))
+        {
+            Logger.LogWarning(
+                "Ambiguous match for feed name '{name}': {count} tracked Players share it and none could be uniquely linked; set DOBs to disambiguate. Candidates: {candidates}",
+                name, players.Count, DescribePlayers(players));
+        }
+        if (ambiguousGroups > MaxAmbiguousGroupsLogged)
+        {
+            Logger.LogInformation("{remaining} additional ambiguous name groups not individually logged.",
+                ambiguousGroups - MaxAmbiguousGroupsLogged);
+        }
+
+        if (unmatchedPlayers > 0)
+        {
+            var sample = await Context.Players
+                .Where(p => !Context.ReferencePlayers.Any(rp => rp.PlayerId == p.Id))
+                .OrderBy(p => p.Id)
+                .Take(MaxUnmatchedSampleLogged)
+                .ToListAsync(cancellation);
+            Logger.LogInformation(
+                "{unmatchedPlayers} tracked Players have no ReferencePlayer (much of this is expected: the feed is current-season MLB only). Sample: {sample}",
+                unmatchedPlayers, DescribePlayers(sample));
+        }
+    }
+
+    private static string DescribePlayers(IEnumerable<Player> players) =>
+        string.Join("; ", players.Select(p => $"#{p.Id} {p.Name} (DOB {p.DateOfBirth?.ToString() ?? "none"})"));
 
     /// <summary>
     /// Limit number of players to process in each batch to avoid overwhelming Fangraphs
@@ -230,7 +340,15 @@ public class ReferenceManager(ILogger<ReferenceManager> logger, BaseballContext 
         };
     }
 
-    private Player? MatchPlayerByMLBAMPlayer(ReferencePlayer referencePlayer, MLBAMPlayer mlbamPlayer)
+    /// <summary>
+    /// Result of attempting to link a feed player to a tracked <see cref="Player"/>. <see cref="Outcome"/>
+    /// is one of the <see cref="ReferenceUpdateMetrics.PlayerMatchOutcome"/> constants; <see cref="AmbiguousPlayers"/>
+    /// carries the colliding Players when <see cref="Outcome"/> is
+    /// <see cref="ReferenceUpdateMetrics.PlayerMatchOutcome.Ambiguous"/>, for end-of-run reporting.
+    /// </summary>
+    private readonly record struct PlayerMatch(Player? Player, string Outcome, List<Player>? AmbiguousPlayers);
+
+    private PlayerMatch MatchPlayerByMLBAMPlayer(ReferencePlayer referencePlayer, MLBAMPlayer mlbamPlayer)
     {
         // First match by name and date of birth
         var referenceName = mlbamPlayer.FullName.ToLowerInvariant();
@@ -239,7 +357,7 @@ public class ReferenceManager(ILogger<ReferenceManager> logger, BaseballContext 
         {
             Logger.LogInformation("Matched MLBAM player {mlbamPlayer} to Player {player} by name and date of birth.",
                 mlbamPlayer.FullName, player.Name);
-            return player;
+            return new PlayerMatch(player, ReferenceUpdateMetrics.PlayerMatchOutcome.LinkedByNameAndDob, null);
         }
         // Next look for a unique match by name only
         var playersByName = Context.Players.Where(p => p.NameNormalized == referenceName).ToList();
@@ -247,16 +365,16 @@ public class ReferenceManager(ILogger<ReferenceManager> logger, BaseballContext 
         {
             Logger.LogInformation("Matched MLBAM player {mlbamPlayer} to Player {player} by name only.",
                 mlbamPlayer.FullName, playersByName.First().Name);
-            return playersByName.First();
+            return new PlayerMatch(playersByName.First(), ReferenceUpdateMetrics.PlayerMatchOutcome.LinkedByNameOnly, null);
         }
         else if (playersByName.Count > 1)
         {
-            // if there are multiple name matches, just warn for now;
-            // probably we should be setting the dob on the player to disambiguate
-            Logger.LogWarning("Warning: multiple players found with name {mlbamPlayerFullName}; cannot match by MLBAMId {mlbamPlayerId}", mlbamPlayer.FullName, mlbamPlayer.Id);
+            // Multiple name matches: can't pick one. These are the actionable cases (set DOBs to
+            // disambiguate); they're collected and logged together at the end of the run.
+            return new PlayerMatch(null, ReferenceUpdateMetrics.PlayerMatchOutcome.Ambiguous, playersByName);
         }
 
-        return null;
+        return new PlayerMatch(null, ReferenceUpdateMetrics.PlayerMatchOutcome.Unmatched, null);
     }
 
     private static string FangraphsIdFromUri(Uri uri)

--- a/BaseballApi/Api/Integrations/ReferenceManager.cs
+++ b/BaseballApi/Api/Integrations/ReferenceManager.cs
@@ -184,11 +184,18 @@ public class ReferenceManager(ILogger<ReferenceManager> logger, BaseballContext 
             .CountAsync(p => Context.ReferencePlayers.Any(rp => rp.PlayerId == p.Id), cancellation);
         var unmatchedPlayers = totalPlayers - matchedPlayers;
         var ambiguousGroups = ambiguousByName.Count;
-        var fixableUnmatched = ambiguousByName.Values
+        // Only the genuinely unmatched members of the ambiguous groups are "fixable". A group can
+        // also contain a Player that's already linked to a ReferencePlayer (e.g. one linked by name
+        // only before a second Player with the same name appeared); counting those would overstate
+        // the fixable-unmatched figure and break its "Unmatched tracked Players" definition.
+        var ambiguousPlayerIds = ambiguousByName.Values
             .SelectMany(players => players)
             .Select(p => p.Id)
             .Distinct()
-            .Count();
+            .ToList();
+        var fixableUnmatched = await Context.Players
+            .CountAsync(p => ambiguousPlayerIds.Contains(p.Id)
+                && !Context.ReferencePlayers.Any(rp => rp.PlayerId == p.Id), cancellation);
 
         Metrics.UpdatePlayerStateSnapshot(new ReferenceUpdateMetrics.PlayerStateSnapshot(
             Matched: matchedPlayers,
@@ -353,7 +360,9 @@ public class ReferenceManager(ILogger<ReferenceManager> logger, BaseballContext 
 
     private PlayerMatch MatchPlayerByMLBAMPlayer(ReferencePlayer referencePlayer, MLBAMPlayer mlbamPlayer)
     {
-        // First match by name and date of birth
+        // First match by name and date of birth. NameNormalized is unaccent_immutable(lower(Name)),
+        // which already strips the diacritics that DB Player names can carry; the MLBAM feed delivers
+        // names without diacritics, so lowering the feed name is enough to line the two up.
         var referenceName = mlbamPlayer.FullName.ToLowerInvariant();
         var player = Context.Players.FirstOrDefault(p => p.NameNormalized == referenceName && p.DateOfBirth == referencePlayer.DateOfBirth);
         if (player != null)

--- a/BaseballApi/Api/Integrations/ReferenceManager.cs
+++ b/BaseballApi/Api/Integrations/ReferenceManager.cs
@@ -232,14 +232,17 @@ public class ReferenceManager(ILogger<ReferenceManager> logger, BaseballContext 
 
         if (unmatchedPlayers > 0)
         {
+            // Newest Players first (highest Id): a Player gets created when a current-season game is
+            // imported, so the most recently added unmatched rows are the ones most likely to be a
+            // real gap worth chasing rather than expected MiLB/historical noise.
             var sample = await Context.Players
                 .Where(p => !Context.ReferencePlayers.Any(rp => rp.PlayerId == p.Id))
-                .OrderBy(p => p.Id)
+                .OrderByDescending(p => p.Id)
                 .Take(MaxUnmatchedSampleLogged)
                 .ToListAsync(cancellation);
             Logger.LogInformation(
-                "{unmatchedPlayers} tracked Players have no ReferencePlayer (much of this is expected: the feed is current-season MLB only). Sample: {sample}",
-                unmatchedPlayers, DescribePlayers(sample));
+                "{unmatchedPlayers} tracked Players have no ReferencePlayer (much of this is expected: the feed is current-season MLB only). {sampleCount} most recently added shown: {sample}",
+                unmatchedPlayers, sample.Count, DescribePlayers(sample));
         }
     }
 

--- a/BaseballApi/Api/Observability/MediaImportMetrics.cs
+++ b/BaseballApi/Api/Observability/MediaImportMetrics.cs
@@ -1,0 +1,63 @@
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+
+namespace BaseballApi.Observability;
+
+/// <summary>
+/// Metrics for the media-import pipeline: the final-outcome counter recorded by the background
+/// service and the queue-depth gauge fed by the import queue. Registered as a DI singleton so its
+/// instruments are created exactly once, under the shared <see cref="Telemetry.MeterName"/> meter.
+/// </summary>
+public sealed class MediaImportMetrics
+{
+    private readonly Counter<long> _outcomes;
+
+    // Supplies the current queue depth to the observable gauge. Written once when the queue is
+    // constructed, read by the metrics export thread; see TrackQueueDepth.
+    private Func<int>? _queueDepth;
+
+    public MediaImportMetrics(IMeterFactory meterFactory)
+    {
+        var meter = meterFactory.Create(Telemetry.MeterName);
+        _outcomes = meter.CreateCounter<long>(
+            "media_import.outcomes",
+            unit: "{import}",
+            description: "Media import runs tagged by their final outcome.");
+        // Early-warning signal that the importer is falling behind, pulled on each collection.
+        meter.CreateObservableGauge(
+            "media_import.queue.depth",
+            ObserveQueueDepth,
+            unit: "{import}",
+            description: "Media imports waiting in the queue to be processed.");
+    }
+
+    /// <summary>Final outcome values for the media-import counter and span tag.</summary>
+    public static class Outcome
+    {
+        public const string Completed = "completed";
+        public const string Failed = "failed";
+        public const string Skipped = "skipped";
+    }
+
+    /// <summary>
+    /// Records a finished media import: increments the outcome counter tagged by
+    /// <paramref name="outcome"/> (use the <see cref="Outcome"/> constants) and, when a job span is
+    /// active, annotates it so a trace can be filtered by the same outcome. A crash mid-import is
+    /// intentionally not an outcome here — that surfaces as a span error instead. The span tag
+    /// rides on <see cref="Activity.Current"/>, so call this while the job's activity is ambient.
+    /// </summary>
+    public void RecordOutcome(string outcome)
+    {
+        _outcomes.Add(1, new KeyValuePair<string, object?>("status", outcome));
+        Activity.Current?.SetTag("import.outcome", outcome);
+    }
+
+    /// <summary>
+    /// Binds the queue-depth gauge to its data source. Call once when the queue is constructed;
+    /// until then the gauge reports nothing rather than a misleading zero.
+    /// </summary>
+    public void TrackQueueDepth(Func<int> queueDepth) => Volatile.Write(ref _queueDepth, queueDepth);
+
+    private IEnumerable<Measurement<int>> ObserveQueueDepth() =>
+        Volatile.Read(ref _queueDepth) is { } depth ? [new Measurement<int>(depth())] : [];
+}

--- a/BaseballApi/Api/Observability/ReferenceUpdateMetrics.cs
+++ b/BaseballApi/Api/Observability/ReferenceUpdateMetrics.cs
@@ -1,0 +1,113 @@
+using System.Diagnostics.Metrics;
+
+namespace BaseballApi.Observability;
+
+/// <summary>
+/// Metrics for the MLBAM reference-update job: a per-feed-player match-outcome counter plus the
+/// post-run match-state gauges. Registered as a DI singleton so its instruments are created
+/// exactly once, under the shared <see cref="Telemetry.MeterName"/> meter.
+/// </summary>
+public sealed class ReferenceUpdateMetrics
+{
+    private readonly Counter<long> _playerMatch;
+
+    // Latest match-state snapshot, published by the reference-update job and read by the metrics
+    // export thread. Accessed through Volatile.Read/Write — see UpdatePlayerStateSnapshot for why.
+    private PlayerStateSnapshot? _playerState;
+
+    public ReferenceUpdateMetrics(IMeterFactory meterFactory)
+    {
+        var meter = meterFactory.Create(Telemetry.MeterName);
+        _playerMatch = meter.CreateCounter<long>(
+            "reference_update.player_match",
+            unit: "{player}",
+            description: "Per-run disposition of each MLBAM feed player when matching it to a tracked Player.");
+        meter.CreateObservableGauge(
+            "reference_update.players",
+            ObservePlayers,
+            unit: "{player}",
+            description: "Tracked Players split by whether they link to a ReferencePlayer, as of the last reference update run.");
+        meter.CreateObservableGauge(
+            "reference_update.ambiguous_name_groups",
+            () => Observe(static s => s.AmbiguousNameGroups),
+            description: "Distinct normalized names that the last run could not uniquely match because multiple Players share them.");
+        meter.CreateObservableGauge(
+            "reference_update.fixable_unmatched",
+            () => Observe(static s => s.FixableUnmatched),
+            unit: "{player}",
+            description: "Unmatched tracked Players that appeared in the feed but could not be disambiguated; fixable by setting a DOB.");
+    }
+
+    /// <summary>
+    /// Final disposition of a single MLBAM feed player during a reference update — each feed
+    /// player is counted under exactly one of these. <see cref="DroppedNoBirthdate"/> never even
+    /// gets a ReferencePlayer; the rest reflect whether/how its ReferencePlayer maps to a tracked
+    /// <c>Player</c>. <see cref="Ambiguous"/> is the actionable failure (fix by adding a DOB).
+    /// </summary>
+    public static class PlayerMatchOutcome
+    {
+        public const string LinkedByNameAndDob = "linked_by_name_and_dob";
+        public const string LinkedByNameOnly = "linked_by_name_only";
+        public const string Ambiguous = "ambiguous";
+        public const string Unmatched = "unmatched";
+        public const string DroppedNoBirthdate = "dropped_no_birthdate";
+    }
+
+    /// <summary>
+    /// Snapshot of tracked-Player match state captured at the end of a reference update run.
+    /// <see cref="FixableUnmatched"/> is the count of Players in this run's ambiguous-name groups
+    /// — unmatched only because the feed player couldn't be disambiguated.
+    /// </summary>
+    public sealed record PlayerStateSnapshot(
+        long Matched,
+        long Unmatched,
+        long AmbiguousNameGroups,
+        long FixableUnmatched);
+
+    /// <summary>
+    /// Increments the player-match counter for one feed player, tagged by its
+    /// <paramref name="outcome"/> (use the <see cref="PlayerMatchOutcome"/> constants). Per-run
+    /// totals are summarized onto the job span separately by the caller.
+    /// </summary>
+    public void RecordPlayerMatchOutcome(string outcome)
+    {
+        _playerMatch.Add(1, new KeyValuePair<string, object?>("outcome", outcome));
+    }
+
+    /// <summary>
+    /// Publishes the latest player match-state snapshot for the observable gauges to report; call
+    /// once at the end of a reference update run.
+    ///
+    /// The job thread writes here while the OpenTelemetry export thread reads in the gauge
+    /// callbacks, so the field needs cross-thread publication. We use <see cref="Volatile.Write"/> /
+    /// <see cref="Volatile.Read"/> on a plain field rather than the <c>volatile</c> keyword (whose
+    /// implicit per-access semantics the C# docs now steer away from) or a lock (heavier than
+    /// needed on the hot export path). This is correct <em>only because the snapshot is immutable
+    /// and swapped wholesale</em>: a reference write is atomic, so a reader observes either the
+    /// complete previous snapshot or the complete new one, never a torn mix of old and new counts.
+    /// <see cref="Volatile.Write"/> supplies the release fence that makes the fully-constructed
+    /// record visible; <see cref="Volatile.Read"/> the matching acquire. We need only eventual
+    /// visibility ("state as of the last completed run"), which this provides; an
+    /// <c>Interlocked.Exchange</c> would also work but we use neither its returned value nor its
+    /// full barrier.
+    /// </summary>
+    public void UpdatePlayerStateSnapshot(PlayerStateSnapshot snapshot) =>
+        Volatile.Write(ref _playerState, snapshot);
+
+    private IEnumerable<Measurement<long>> ObservePlayers()
+    {
+        var state = Volatile.Read(ref _playerState);
+        if (state is null)
+        {
+            yield break;
+        }
+        yield return new Measurement<long>(state.Matched, new KeyValuePair<string, object?>("matched", true));
+        yield return new Measurement<long>(state.Unmatched, new KeyValuePair<string, object?>("matched", false));
+    }
+
+    private IEnumerable<Measurement<long>> Observe(Func<PlayerStateSnapshot, long> selector)
+    {
+        var state = Volatile.Read(ref _playerState);
+        return state is null ? [] : [new Measurement<long>(selector(state))];
+    }
+}

--- a/BaseballApi/Api/Observability/Telemetry.cs
+++ b/BaseballApi/Api/Observability/Telemetry.cs
@@ -1,16 +1,20 @@
 using System.Diagnostics;
-using System.Diagnostics.Metrics;
 
 namespace BaseballApi.Observability;
 
 /// <summary>
-/// Shared telemetry primitives for background-job tracing and metrics. The
-/// <see cref="ActivitySource"/> and <see cref="Meter"/> are registered with the
-/// OpenTelemetry pipeline in <c>Program.cs</c> via
-/// <c>AddSource(Telemetry.BackgroundJobsSourceName)</c> and
-/// <c>AddMeter(Telemetry.MeterName)</c>; without those registrations
-/// <see cref="ActivitySource.StartActivity(string, ActivityKind)"/> returns null, so all
-/// span call sites must null-condition the returned activity.
+/// Shared, cross-cutting telemetry plumbing: the background-job <see cref="ActivitySource"/>, the
+/// common job-exception helper, and the OpenTelemetry meter name that every per-subsystem metrics
+/// class creates its instruments under. The source and meter name are registered with the
+/// OpenTelemetry pipeline in <c>Program.cs</c> via <c>AddSource(Telemetry.BackgroundJobsSourceName)</c>
+/// and <c>AddMeter(Telemetry.MeterName)</c>; without those registrations
+/// <see cref="ActivitySource.StartActivity(string, ActivityKind)"/> returns null, so span call
+/// sites must null-condition the returned activity.
+///
+/// Metrics deliberately do NOT live here. Each subsystem owns a dedicated, DI-registered metrics
+/// class (e.g. <c>MediaImportMetrics</c>, <c>ReferenceUpdateMetrics</c>) holding its own
+/// instruments, tag constants, and any cached gauge state, so this stays a thin shared core
+/// rather than a grab-bag that grows with every new metric.
 /// </summary>
 public static class Telemetry
 {
@@ -18,22 +22,11 @@ public static class Telemetry
 
     public static readonly ActivitySource BackgroundJobs = new(BackgroundJobsSourceName);
 
+    /// <summary>
+    /// Meter name shared by every custom metric. Per-subsystem metrics classes pass this to
+    /// <c>IMeterFactory.Create</c>, and <c>Program.cs</c> registers it with <c>AddMeter</c>.
+    /// </summary>
     public const string MeterName = "BaseballApi";
-
-    public static readonly Meter Meter = new(MeterName);
-
-    private static readonly Counter<long> MediaImportOutcomeCounter = Meter.CreateCounter<long>(
-        "media_import.outcomes",
-        unit: "{import}",
-        description: "Media import runs tagged by their final outcome.");
-
-    /// <summary>Final outcome values for the media-import counter and span tag.</summary>
-    public static class MediaImportOutcome
-    {
-        public const string Completed = "completed";
-        public const string Failed = "failed";
-        public const string Skipped = "skipped";
-    }
 
     /// <summary>
     /// Flags a background-job span as failed for an exception, except for cancellation:
@@ -49,19 +42,5 @@ public static class Telemetry
         }
         activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
         activity?.AddException(ex);
-    }
-
-    /// <summary>
-    /// Records a finished media import: increments the outcome counter tagged by
-    /// <paramref name="outcome"/> (use the <see cref="MediaImportOutcome"/> constants) and, when a
-    /// job span is active, annotates it so a trace can be filtered by the same outcome. A
-    /// crash mid-import is intentionally not an outcome here — that surfaces as a span error
-    /// instead. Note the span tag rides on <see cref="Activity.Current"/>, so call this while
-    /// the job's activity is the ambient one.
-    /// </summary>
-    public static void RecordMediaImportOutcome(string outcome)
-    {
-        MediaImportOutcomeCounter.Add(1, new KeyValuePair<string, object?>("status", outcome));
-        Activity.Current?.SetTag("import.outcome", outcome);
     }
 }

--- a/BaseballApi/Api/Program.cs
+++ b/BaseballApi/Api/Program.cs
@@ -106,6 +106,12 @@ builder.Services.AddHttpClient<FangraphsConnector>(client =>
     client.BaseAddress = new Uri("https://www.fangraphs.com/api/search/players/");
 });
 builder.Services.AddScoped<ReferenceManager, ReferenceManager>();
+// Per-subsystem metrics: singletons so each owns its instruments for the process lifetime. They
+// pull a Meter from IMeterFactory, which AddMetrics registers (and which the metric collection
+// is built on regardless of whether the OTLP exporter above is configured).
+builder.Services.AddMetrics();
+builder.Services.AddSingleton<MediaImportMetrics>();
+builder.Services.AddSingleton<ReferenceUpdateMetrics>();
 builder.Services.AddSingleton<IMediaImportQueue, MediaImportQueue>();
 builder.Services.AddHostedService<RemoteLogService>();
 builder.Services.AddHostedService<MediaImportBackgroundService>();

--- a/BaseballApi/Api/Services/MediaImportBackgroundService.cs
+++ b/BaseballApi/Api/Services/MediaImportBackgroundService.cs
@@ -9,11 +9,13 @@ namespace BaseballApi.Services;
 public class MediaImportBackgroundService(
         IMediaImportQueue mediaImportQueue,
         IServiceProvider serviceProvider,
-        ILogger<MediaImportBackgroundService> logger) : BackgroundService
+        ILogger<MediaImportBackgroundService> logger,
+        MediaImportMetrics metrics) : BackgroundService
 {
     private IMediaImportQueue MediaImportQueue { get; } = mediaImportQueue;
     private IServiceProvider ServiceProvider { get; } = serviceProvider;
     private ILogger<MediaImportBackgroundService> Logger { get; } = logger;
+    private MediaImportMetrics Metrics { get; } = metrics;
 
     protected override async Task ExecuteAsync(CancellationToken cancellationToken)
     {
@@ -81,7 +83,7 @@ public class MediaImportBackgroundService(
         if (importTask == null)
         {
             Logger.LogWarning("Import task not found.");
-            Telemetry.RecordMediaImportOutcome(Telemetry.MediaImportOutcome.Skipped);
+            Metrics.RecordOutcome(MediaImportMetrics.Outcome.Skipped);
             return;
         }
 
@@ -89,7 +91,7 @@ public class MediaImportBackgroundService(
             importTask.Status != MediaImportTaskStatus.InProgress)
         {
             Logger.LogWarning("Import task is not in a valid state for processing: {Status}", importTask.Status);
-            Telemetry.RecordMediaImportOutcome(Telemetry.MediaImportOutcome.Skipped);
+            Metrics.RecordOutcome(MediaImportMetrics.Outcome.Skipped);
             return;
         }
 
@@ -125,12 +127,12 @@ public class MediaImportBackgroundService(
         if (errorCount == 0)
         {
             importTask.Status = MediaImportTaskStatus.Completed;
-            Telemetry.RecordMediaImportOutcome(Telemetry.MediaImportOutcome.Completed);
+            Metrics.RecordOutcome(MediaImportMetrics.Outcome.Completed);
         }
         else
         {
             importTask.Status = MediaImportTaskStatus.Failed;
-            Telemetry.RecordMediaImportOutcome(Telemetry.MediaImportOutcome.Failed);
+            Metrics.RecordOutcome(MediaImportMetrics.Outcome.Failed);
         }
         importTask.CompletedAt = DateTimeOffset.UtcNow;
         await context.SaveChangesAsync(cancellationToken);

--- a/BaseballApi/Api/Services/MediaImportQueue.cs
+++ b/BaseballApi/Api/Services/MediaImportQueue.cs
@@ -9,17 +9,12 @@ public class MediaImportQueue : IMediaImportQueue
     private ILogger<MediaImportQueue> Logger { get; }
     private bool _importInProgress;
 
-    public MediaImportQueue(ILogger<MediaImportQueue> logger)
+    public MediaImportQueue(ILogger<MediaImportQueue> logger, MediaImportMetrics metrics)
     {
         Logger = logger;
-        // Early-warning signal that the importer is falling behind, read from the unbounded
-        // channel on each metric collection. No need to keep the returned instrument: the
-        // Meter retains it, and observable gauges are pull-based so we never touch it again.
-        Telemetry.Meter.CreateObservableGauge(
-            "media_import.queue.depth",
-            () => Count,
-            unit: "{import}",
-            description: "Media imports waiting in the queue to be processed.");
+        // The queue-depth gauge is defined on MediaImportMetrics; bind it to this queue's count so
+        // the importer's backlog shows up as an early-warning signal when it's falling behind.
+        metrics.TrackQueueDepth(() => Count);
     }
 
     public int Count => Queue.Reader.Count;

--- a/BaseballApi/ApiTests/BaseballTests.cs
+++ b/BaseballApi/ApiTests/BaseballTests.cs
@@ -1,6 +1,7 @@
 using System.Reflection;
 using BaseballApi.Integrations;
 using BaseballApi.Models;
+using BaseballApi.Observability;
 using BaseballApi.Services;
 using Microsoft.Extensions.Logging;
 
@@ -11,11 +12,19 @@ public abstract class BaseballTests : IClassFixture<TestDatabaseFixture>, IClass
     protected BaseballContext Context { get; }
     protected TestDatabaseFixture Fixture { get; }
     protected ILoggerFactory FileLoggerFactory { get; }
+
+    private TestMeterFactory MeterFactory { get; }
+    protected MediaImportMetrics MediaMetrics { get; }
+    protected ReferenceUpdateMetrics ReferenceMetrics { get; }
+
     protected BaseballTests(TestDatabaseFixture fixture, TestFileLoggerFixture fileLoggerFixture)
     {
         Fixture = fixture;
         FileLoggerFactory = fileLoggerFixture.FileLoggerFactory;
         Context = TestDatabaseFixture.CreateContext();
+        MeterFactory = new TestMeterFactory();
+        MediaMetrics = new MediaImportMetrics(MeterFactory);
+        ReferenceMetrics = new ReferenceUpdateMetrics(MeterFactory);
         // Context.Database.BeginTransaction(); // allow changes without persisting to the db
     }
 
@@ -35,6 +44,7 @@ public abstract class BaseballTests : IClassFixture<TestDatabaseFixture>, IClass
     public void Dispose()
     {
         Context.Dispose();
+        MeterFactory.Dispose();
         GC.SuppressFinalize(this);
     }
 }

--- a/BaseballApi/ApiTests/MediaFormatManagerTests.cs
+++ b/BaseballApi/ApiTests/MediaFormatManagerTests.cs
@@ -3,6 +3,7 @@ using BaseballApi.Contracts;
 using BaseballApi.Controllers;
 using BaseballApi.Import;
 using BaseballApi.Models;
+using BaseballApi.Observability;
 using BaseballApi.Services;
 using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
@@ -37,7 +38,8 @@ public class MediaFormatManagerTests : IClassFixture<TestMediaImportDatabaseFixt
         RemoteValidator = new(RemoteFileManager);
         LoggerFactory = fileLoggerFixture.FileLoggerFactory;
         var logger = LoggerFactory.CreateLogger<MediaImportQueue>();
-        MediaImportQueue mediaImportQueue = new(logger);
+        var mediaMetrics = new MediaImportMetrics(new TestMeterFactory());
+        MediaImportQueue mediaImportQueue = new(logger, mediaMetrics);
 
         IServiceCollection services = new ServiceCollection();
         services.AddSingleton<IRemoteFileManager>(RemoteFileManager);
@@ -45,7 +47,7 @@ public class MediaFormatManagerTests : IClassFixture<TestMediaImportDatabaseFixt
             opt.UseNpgsql(Context.Database.GetConnectionString()));
         var serviceProvider = services.BuildServiceProvider();
         var backgroundLogger = LoggerFactory.CreateLogger<MediaImportBackgroundService>();
-        var backgroundService = new MediaImportBackgroundService(mediaImportQueue, serviceProvider, backgroundLogger);
+        var backgroundService = new MediaImportBackgroundService(mediaImportQueue, serviceProvider, backgroundLogger, mediaMetrics);
         Manager = new(mediaImportQueue, serviceProvider, logger, CancellationToken.None);
 
         var controller = new MediaController(Context, RemoteFileManager, mediaImportQueue);

--- a/BaseballApi/ApiTests/MediaFormatManagerTests.cs
+++ b/BaseballApi/ApiTests/MediaFormatManagerTests.cs
@@ -22,6 +22,7 @@ public class MediaFormatManagerTests : IClassFixture<TestMediaImportDatabaseFixt
     MediaFormatManager Manager { get; }
     TestMediaImporter Importer { get; }
     private ILoggerFactory LoggerFactory { get; }
+    private TestMeterFactory MeterFactory { get; }
     long GameId { get { return Fixture.GameId; } }
 
     public MediaFormatManagerTests(TestMediaImportDatabaseFixture fixture, TestFileLoggerFixture fileLoggerFixture)
@@ -38,7 +39,8 @@ public class MediaFormatManagerTests : IClassFixture<TestMediaImportDatabaseFixt
         RemoteValidator = new(RemoteFileManager);
         LoggerFactory = fileLoggerFixture.FileLoggerFactory;
         var logger = LoggerFactory.CreateLogger<MediaImportQueue>();
-        var mediaMetrics = new MediaImportMetrics(new TestMeterFactory());
+        MeterFactory = new TestMeterFactory();
+        var mediaMetrics = new MediaImportMetrics(MeterFactory);
         MediaImportQueue mediaImportQueue = new(logger, mediaMetrics);
 
         IServiceCollection services = new ServiceCollection();
@@ -610,6 +612,7 @@ public class MediaFormatManagerTests : IClassFixture<TestMediaImportDatabaseFixt
     public async Task DisposeAsync()
     {
         await RemoteFileManager.DeleteFolder();
+        MeterFactory.Dispose();
     }
 
 }

--- a/BaseballApi/ApiTests/MediaImportMetricsTests.cs
+++ b/BaseballApi/ApiTests/MediaImportMetricsTests.cs
@@ -11,7 +11,7 @@ namespace BaseballApiTests;
 /// rather than a real exporter, so they need no collector or database. Each test builds its own
 /// <see cref="MediaImportMetrics"/> from a <see cref="TestMeterFactory"/>.
 /// </summary>
-public class MetricsTests
+public class MediaImportMetricsTests
 {
     [Fact]
     [Trait(TestCategory.Category, TestCategory.Observability)]

--- a/BaseballApi/ApiTests/MediaTests.cs
+++ b/BaseballApi/ApiTests/MediaTests.cs
@@ -34,7 +34,7 @@ public class MediaTests : BaseballTests, IAsyncLifetime
         RemoteFileManager = new(configuration, nameof(MediaTests));
         RemoteValidator = new(RemoteFileManager);
         var logger = FileLoggerFactory.CreateLogger<MediaImportQueue>();
-        MediaImportQueue mediaImportQueue = new(logger);
+        MediaImportQueue mediaImportQueue = new(logger, MediaMetrics);
         Controller = new MediaController(Context, RemoteFileManager, mediaImportQueue);
         TestGameManager = new TestGameManager(Context);
 
@@ -45,7 +45,7 @@ public class MediaTests : BaseballTests, IAsyncLifetime
             opt.UseNpgsql(Context.Database.GetConnectionString()));
         var serviceProvider = services.BuildServiceProvider();
         var backgroundLogger = FileLoggerFactory.CreateLogger<MediaImportBackgroundService>();
-        MediaImportBackgroundService = new MediaImportBackgroundService(mediaImportQueue, serviceProvider, backgroundLogger);
+        MediaImportBackgroundService = new MediaImportBackgroundService(mediaImportQueue, serviceProvider, backgroundLogger, MediaMetrics);
         var mediaImportTaskRestarterLogger = FileLoggerFactory.CreateLogger<MediaImportTaskRestarter>();
         MediaImportTaskRestarter = new MediaImportTaskRestarter(mediaImportQueue, serviceProvider, mediaImportTaskRestarterLogger);
         var tempFileCleanerLogger = FileLoggerFactory.CreateLogger<TempFileCleaner>();

--- a/BaseballApi/ApiTests/MetricsTests.cs
+++ b/BaseballApi/ApiTests/MetricsTests.cs
@@ -6,16 +6,20 @@ using Microsoft.Extensions.Logging.Abstractions;
 namespace BaseballApiTests;
 
 /// <summary>
-/// Verifies the custom metrics (import-outcome counter + queue-depth gauge) emit through
-/// the shared <see cref="Telemetry.Meter"/>. Like the span tests these use an in-process
-/// listener rather than a real exporter, so they need no collector or database.
+/// Verifies the media-import metrics (outcome counter + queue-depth gauge) emit through the shared
+/// <see cref="Telemetry.MeterName"/> meter. Like the span tests these use an in-process listener
+/// rather than a real exporter, so they need no collector or database. Each test builds its own
+/// <see cref="MediaImportMetrics"/> from a <see cref="TestMeterFactory"/>.
 /// </summary>
 public class MetricsTests
 {
     [Fact]
     [Trait(TestCategory.Category, TestCategory.Observability)]
-    public void RecordMediaImportOutcome_IncrementsCounterWithStatusTag()
+    public void RecordOutcome_IncrementsCounterWithStatusTag()
     {
+        using var meterFactory = new TestMeterFactory();
+        var metrics = new MediaImportMetrics(meterFactory);
+
         var measurements = new List<(long Value, string? Status)>();
         using var listener = new MeterListener
         {
@@ -41,10 +45,10 @@ public class MetricsTests
         });
         listener.Start();
 
-        Telemetry.RecordMediaImportOutcome(Telemetry.MediaImportOutcome.Failed);
+        metrics.RecordOutcome(MediaImportMetrics.Outcome.Failed);
 
-        // Contains rather than Single: the counter is static, so a parallel test could record
-        // its own outcome while this listener is active.
+        // Contains rather than Single: a parallel test could record its own outcome on another
+        // MediaImportMetrics instance while this listener is active (same shared meter name).
         Assert.Contains(measurements, m => m.Value == 1 && m.Status == "failed");
     }
 
@@ -52,7 +56,10 @@ public class MetricsTests
     [Trait(TestCategory.Category, TestCategory.Observability)]
     public async Task QueueDepthGauge_ReportsCurrentQueueCount()
     {
-        var queue = new MediaImportQueue(NullLogger<MediaImportQueue>.Instance);
+        using var meterFactory = new TestMeterFactory();
+        var metrics = new MediaImportMetrics(meterFactory);
+        // Constructing the queue binds the gauge to its count.
+        var queue = new MediaImportQueue(NullLogger<MediaImportQueue>.Instance, metrics);
         // Three queued, none popped: a distinctive count so it's not confused with the
         // (typically empty) queues other test classes may hold alive on the shared meter.
         await queue.PushAsync(Guid.NewGuid());

--- a/BaseballApi/ApiTests/PlayerTests.cs
+++ b/BaseballApi/ApiTests/PlayerTests.cs
@@ -140,11 +140,11 @@ public class PlayerTests : BaseballTests
         var fangraphsConnector = CreateFangraphsConnector();
         // update teams so the MLBAM IDs are present
         var realConnector = new MLBAMConnector(CreateMLBAMHttpClient());
-        var realReferenceManager = new ReferenceManager(logger, Context, realConnector, fangraphsConnector);
+        var realReferenceManager = new ReferenceManager(logger, Context, realConnector, fangraphsConnector, ReferenceMetrics);
         var teamsUpdated = await realReferenceManager.UpdateTeamReferences(CancellationToken.None);
 
         var connector = new MockMLBAMConnector();
-        var referenceManager = new ReferenceManager(logger, Context, connector, fangraphsConnector);
+        var referenceManager = new ReferenceManager(logger, Context, connector, fangraphsConnector, ReferenceMetrics);
         var result = await referenceManager.UpdatePlayerReferences(CancellationToken.None);
         Assert.Equal(1, result.CreatedCount);
         Assert.Equal(2, result.UpdatedCount);
@@ -190,11 +190,11 @@ public class PlayerTests : BaseballTests
         var logger = FileLoggerFactory.CreateLogger<ReferenceManager>();
         var fangraphsConnector = CreateFangraphsConnector();
         var realConnector = new MLBAMConnector(CreateMLBAMHttpClient());
-        var realReferenceManager = new ReferenceManager(logger, Context, realConnector, fangraphsConnector);
+        var realReferenceManager = new ReferenceManager(logger, Context, realConnector, fangraphsConnector, ReferenceMetrics);
         var teamsUpdated = await realReferenceManager.UpdateTeamReferences(CancellationToken.None);
 
         var connector = new MockMLBAMConnector();
-        var referenceManager = new ReferenceManager(logger, Context, connector, fangraphsConnector);
+        var referenceManager = new ReferenceManager(logger, Context, connector, fangraphsConnector, ReferenceMetrics);
         var result = await referenceManager.UpdatePlayerReferences(CancellationToken.None);
 
         var dodgers = Context.Teams.First(t => t.Abbreviation == "LAD");

--- a/BaseballApi/ApiTests/ReferenceUpdateMetricsTests.cs
+++ b/BaseballApi/ApiTests/ReferenceUpdateMetricsTests.cs
@@ -1,0 +1,134 @@
+using System.Diagnostics.Metrics;
+using BaseballApi.Observability;
+
+namespace BaseballApiTests;
+
+/// <summary>
+/// Verifies the MLBAM reference-update metrics (the player-match outcome counter and the post-run
+/// match-state gauges) emit through the shared <see cref="Telemetry.MeterName"/> meter. Like the
+/// other metrics tests these use an in-process <see cref="MeterListener"/> rather than a real
+/// exporter, so they need no collector or database. Each test builds its own
+/// <see cref="ReferenceUpdateMetrics"/> from a <see cref="TestMeterFactory"/>.
+/// </summary>
+public class ReferenceUpdateMetricsTests
+{
+    [Fact]
+    [Trait(TestCategory.Category, TestCategory.Observability)]
+    public void RecordPlayerMatchOutcome_IncrementsCounterWithOutcomeTag()
+    {
+        using var meterFactory = new TestMeterFactory();
+        var metrics = new ReferenceUpdateMetrics(meterFactory);
+
+        var measurements = new List<(long Value, string? Outcome)>();
+        using var listener = new MeterListener
+        {
+            InstrumentPublished = (instrument, l) =>
+            {
+                if (instrument.Meter.Name == Telemetry.MeterName && instrument.Name == "reference_update.player_match")
+                {
+                    l.EnableMeasurementEvents(instrument);
+                }
+            },
+        };
+        listener.SetMeasurementEventCallback<long>((_, value, tags, _) =>
+        {
+            string? outcome = null;
+            foreach (var tag in tags)
+            {
+                if (tag.Key == "outcome")
+                {
+                    outcome = tag.Value as string;
+                }
+            }
+            measurements.Add((value, outcome));
+        });
+        listener.Start();
+
+        metrics.RecordPlayerMatchOutcome(ReferenceUpdateMetrics.PlayerMatchOutcome.Ambiguous);
+
+        // Contains rather than Single: a parallel test could record its own outcome on another
+        // ReferenceUpdateMetrics instance while this listener is active (same shared meter name).
+        Assert.Contains(measurements, m => m.Value == 1 && m.Outcome == "ambiguous");
+    }
+
+    [Fact]
+    [Trait(TestCategory.Category, TestCategory.Observability)]
+    public void PlayersGauge_ReportsLatestSnapshotSplitByMatched()
+    {
+        using var meterFactory = new TestMeterFactory();
+        var metrics = new ReferenceUpdateMetrics(meterFactory);
+        // Distinctive counts so they aren't confused with snapshots other test classes may have
+        // published on the shared meter.
+        metrics.UpdatePlayerStateSnapshot(new ReferenceUpdateMetrics.PlayerStateSnapshot(
+            Matched: 4242,
+            Unmatched: 1717,
+            AmbiguousNameGroups: 0,
+            FixableUnmatched: 0));
+
+        var measurements = new List<(long Value, bool? Matched)>();
+        using var listener = new MeterListener
+        {
+            InstrumentPublished = (instrument, l) =>
+            {
+                if (instrument.Meter.Name == Telemetry.MeterName && instrument.Name == "reference_update.players")
+                {
+                    l.EnableMeasurementEvents(instrument);
+                }
+            },
+        };
+        listener.SetMeasurementEventCallback<long>((_, value, tags, _) =>
+        {
+            bool? matched = null;
+            foreach (var tag in tags)
+            {
+                if (tag.Key == "matched")
+                {
+                    matched = tag.Value as bool?;
+                }
+            }
+            measurements.Add((value, matched));
+        });
+        listener.Start();
+
+        listener.RecordObservableInstruments();
+
+        Assert.Contains(measurements, m => m.Value == 4242 && m.Matched == true);
+        Assert.Contains(measurements, m => m.Value == 1717 && m.Matched == false);
+    }
+
+    [Fact]
+    [Trait(TestCategory.Category, TestCategory.Observability)]
+    public void ScalarGauges_ReportLatestSnapshotValues()
+    {
+        using var meterFactory = new TestMeterFactory();
+        var metrics = new ReferenceUpdateMetrics(meterFactory);
+        // Distinctive values so they aren't confused with snapshots other test classes may have
+        // published on the shared meter (hence Contains rather than an exact lookup below).
+        metrics.UpdatePlayerStateSnapshot(new ReferenceUpdateMetrics.PlayerStateSnapshot(
+            Matched: 0,
+            Unmatched: 0,
+            AmbiguousNameGroups: 91,
+            FixableUnmatched: 73));
+
+        var measurements = new List<(string Instrument, long Value)>();
+        using var listener = new MeterListener
+        {
+            InstrumentPublished = (instrument, l) =>
+            {
+                if (instrument.Meter.Name == Telemetry.MeterName
+                    && (instrument.Name == "reference_update.ambiguous_name_groups"
+                        || instrument.Name == "reference_update.fixable_unmatched"))
+                {
+                    l.EnableMeasurementEvents(instrument);
+                }
+            },
+        };
+        listener.SetMeasurementEventCallback<long>((instrument, value, _, _) => measurements.Add((instrument.Name, value)));
+        listener.Start();
+
+        listener.RecordObservableInstruments();
+
+        Assert.Contains(("reference_update.ambiguous_name_groups", 91L), measurements);
+        Assert.Contains(("reference_update.fixable_unmatched", 73L), measurements);
+    }
+}

--- a/BaseballApi/ApiTests/TeamTests.cs
+++ b/BaseballApi/ApiTests/TeamTests.cs
@@ -59,7 +59,7 @@ public class TeamTests : BaseballTests
     {
         var logger = FileLoggerFactory.CreateLogger<ReferenceManager>();
         var connector = new MLBAMConnector(CreateMLBAMHttpClient());
-        var referenceManager = new ReferenceManager(logger, Context, connector, CreateFangraphsConnector());
+        var referenceManager = new ReferenceManager(logger, Context, connector, CreateFangraphsConnector(), ReferenceMetrics);
         var updatedCount = await referenceManager.UpdateTeamReferences(CancellationToken.None);
         var rangers = Context.Teams.First(t => t.Abbreviation == "TEX");
         Assert.Equal(140, rangers.MLBAMId);

--- a/BaseballApi/ApiTests/TestMeterFactory.cs
+++ b/BaseballApi/ApiTests/TestMeterFactory.cs
@@ -1,0 +1,29 @@
+using System.Diagnostics.Metrics;
+
+namespace BaseballApiTests;
+
+/// <summary>
+/// Minimal <see cref="IMeterFactory"/> for tests that construct metrics classes directly (the test
+/// project doesn't pull in the ASP.NET hosting stack that registers a real one). Each created
+/// <see cref="Meter"/> is tracked and disposed with the factory.
+/// </summary>
+internal sealed class TestMeterFactory : IMeterFactory
+{
+    private readonly List<Meter> _meters = [];
+
+    public Meter Create(MeterOptions options)
+    {
+        var meter = new Meter(options);
+        _meters.Add(meter);
+        return meter;
+    }
+
+    public void Dispose()
+    {
+        foreach (var meter in _meters)
+        {
+            meter.Dispose();
+        }
+        _meters.Clear();
+    }
+}


### PR DESCRIPTION
Track detailed outcomes for background job matching current active players from MLBAM feed to tracked Players. Also refactors Telemetry to separate helpers for distinct sets of metrics.