### PR TITLE
Ride CDN cache and retry MLBAM reference updates

### DIFF
--- a/BaseballApi/Api/Program.cs
+++ b/BaseballApi/Api/Program.cs
@@ -100,6 +100,14 @@ builder.Services.AddScoped<IRemoteLogManager, RemoteLogManager>();
 builder.Services.AddHttpClient<IMLBAMConnector, MLBAMConnector>(client =>
 {
     client.BaseAddress = new Uri("https://statsapi.mlb.com/api/v1/");
+})
+// Request compressed responses so we share the cache variant that public traffic keeps
+// warm in MLB's CDN: statsapi's origin 406s requests from DigitalOcean IPs, so a cache
+// miss means a failed update. For the same reason, avoid statsapi query params that
+// produce unique URLs — a unique cache key guarantees a miss.
+.ConfigurePrimaryHttpMessageHandler(() => new SocketsHttpHandler
+{
+    AutomaticDecompression = System.Net.DecompressionMethods.All,
 });
 builder.Services.AddHttpClient<FangraphsConnector>(client =>
 {

--- a/BaseballApi/Api/Services/ReferenceUpdateService.cs
+++ b/BaseballApi/Api/Services/ReferenceUpdateService.cs
@@ -40,6 +40,10 @@ public class ReferenceUpdateService(
                 referenceManager => referenceManager.UpdateTeamReferences(CancellationToken));
             Logger.LogInformation("Team reference update completed. {updatedCount} teams updated.", updatedCount);
         }
+        catch (OperationCanceledException) when (CancellationToken.IsCancellationRequested)
+        {
+            Logger.LogInformation("Team reference update cancelled during shutdown.");
+        }
         catch (Exception ex)
         {
             Telemetry.RecordJobException(activity, ex);
@@ -56,6 +60,10 @@ public class ReferenceUpdateService(
                 referenceManager => referenceManager.UpdatePlayerReferences(CancellationToken));
             Logger.LogInformation("Player reference update completed. {createdCount} players created, {updatedCount} players updated.",
                 result.CreatedCount, result.UpdatedCount);
+        }
+        catch (OperationCanceledException) when (CancellationToken.IsCancellationRequested)
+        {
+            Logger.LogInformation("Player reference update cancelled during shutdown.");
         }
         catch (Exception ex)
         {
@@ -96,6 +104,10 @@ public class ReferenceUpdateService(
             var result = await referenceManager.UpdateFangraphsLinks(CancellationToken);
             Logger.LogInformation("Fangraphs link update completed. {playerUpdateCount} players updated, {referencePlayerUpdateCount} reference players updated.",
                 result.PlayersUpdated, result.ReferencePlayersUpdated);
+        }
+        catch (OperationCanceledException) when (CancellationToken.IsCancellationRequested)
+        {
+            Logger.LogInformation("Fangraphs link update cancelled during shutdown.");
         }
         catch (Exception ex)
         {

--- a/BaseballApi/Api/Services/ReferenceUpdateService.cs
+++ b/BaseballApi/Api/Services/ReferenceUpdateService.cs
@@ -36,9 +36,8 @@ public class ReferenceUpdateService(
         using var activity = Telemetry.StartJob("job.update-team-references");
         try
         {
-            using var scope = ServiceProvider.CreateScope();
-            var referenceManager = scope.ServiceProvider.GetRequiredService<ReferenceManager>();
-            var updatedCount = await referenceManager.UpdateTeamReferences(CancellationToken);
+            var updatedCount = await RunWithRetry("Team reference update",
+                referenceManager => referenceManager.UpdateTeamReferences(CancellationToken));
             Logger.LogInformation("Team reference update completed. {updatedCount} teams updated.", updatedCount);
         }
         catch (Exception ex)
@@ -53,9 +52,8 @@ public class ReferenceUpdateService(
         using var activity = Telemetry.StartJob("job.update-player-references");
         try
         {
-            using var scope = ServiceProvider.CreateScope();
-            var referenceManager = scope.ServiceProvider.GetRequiredService<ReferenceManager>();
-            var result = await referenceManager.UpdatePlayerReferences(CancellationToken);
+            var result = await RunWithRetry("Player reference update",
+                referenceManager => referenceManager.UpdatePlayerReferences(CancellationToken));
             Logger.LogInformation("Player reference update completed. {createdCount} players created, {updatedCount} players updated.",
                 result.CreatedCount, result.UpdatedCount);
         }
@@ -63,6 +61,28 @@ public class ReferenceUpdateService(
         {
             Telemetry.RecordJobException(activity, ex);
             Logger.LogError(ex, "Error occurred while updating player references.");
+        }
+    }
+
+    private async Task<T> RunWithRetry<T>(string jobName, Func<ReferenceManager, Task<T>> update)
+    {
+        // Spaced retries because an HTTP failure here is usually a CDN cache miss reaching
+        // statsapi's origin, which rejects requests from our host's IP range; the shared
+        // cache variant is typically repopulated by public traffic within minutes.
+        for (var attempt = 1; ; attempt++)
+        {
+            try
+            {
+                using var scope = ServiceProvider.CreateScope();
+                var referenceManager = scope.ServiceProvider.GetRequiredService<ReferenceManager>();
+                return await update(referenceManager);
+            }
+            catch (HttpRequestException ex) when (attempt < 3)
+            {
+                Logger.LogWarning(ex, "{jobName} attempt {attempt} failed; retrying in 10 minutes.",
+                    jobName, attempt);
+                await Task.Delay(TimeSpan.FromMinutes(10), CancellationToken);
+            }
         }
     }
 


### PR DESCRIPTION
statsapi.mlb.com's origin rejects requests from DigitalOcean IPs with 406s, so any request that misses Fastly's cache fails. The player update always missed because sending no Accept-Encoding requests the identity cache variant nobody else keeps warm.

Request compressed responses so the MLBAM client shares the cache variant warmed by public traffic, and retry both MLBAM jobs on HTTP failure (3 attempts, 10 minutes apart) since a miss's variant is typically repopulated within minutes.

Fixes #151 