### PR TITLE
Better time zone handling on imports

### DIFF
--- a/BaseballApi/Api/Import/GameImportManager.cs
+++ b/BaseballApi/Api/Import/GameImportManager.cs
@@ -11,21 +11,29 @@ public class GameImportManager(GameImportData data, BaseballContext context)
     Dictionary<ImportFileType, CsvLoader> Files { get; } = [];
     private PlayerManager PlayerManager { get; } = new PlayerManager(context);
     public string? ScorecardFilePath { get; private set; }
+    private TimeZoneInfo? ParkTimeZone { get; set; }
     private DateOnly GameDate
     {
         get
         {
-            var gameDate = Metadata.ActualStart?.Date ?? Metadata.ScheduledStart?.Date;
-            if (!gameDate.HasValue)
+            // Match the iScore importer precedence for now, see #154
+            var start = Metadata.ScheduledStart ?? Metadata.ActualStart;
+            if (!start.HasValue)
             {
                 throw new ArgumentException("Must provide either actual or scheduled start time");
             }
-            return DateOnly.FromDateTime(gameDate.Value);
+            var parkTime = ParkTimeZone == null
+                ? start.Value
+                : TimeZoneInfo.ConvertTime(start.Value, ParkTimeZone);
+            return DateOnly.FromDateTime(parkTime.Date);
         }
     }
 
     public async Task<Game> GetGame()
     {
+        var home = await this.GetTeam(Metadata.Home.City, Metadata.Home.Name);
+        var away = await this.GetTeam(Metadata.Away.City, Metadata.Away.Name);
+        this.ParkTimeZone = GetTimeZone(home.HomePark);
         var gameDate = GameDate;
         var awayTeamName = $"{Metadata.Away.City} {Metadata.Away.Name}";
         var homeTeamName = $"{Metadata.Home.City} {Metadata.Home.Name}";
@@ -40,12 +48,22 @@ public class GameImportManager(GameImportData data, BaseballContext context)
             EndTime = Metadata.End?.ToUniversalTime(),
             GameType = Metadata.GameType,
             HomeTeamName = homeTeamName,
-            Home = await this.GetTeam(Metadata.Home.City, Metadata.Home.Name),
+            Home = home,
             AwayTeamName = awayTeamName,
-            Away = await this.GetTeam(Metadata.Away.City, Metadata.Away.Name),
+            Away = away,
             Scorecard = this.GetScorecard(),
             BoxScores = []
         };
+    }
+
+    private static TimeZoneInfo? GetTimeZone(Park? park)
+    {
+        if (park?.TimeZone is string timeZoneId
+            && TimeZoneInfo.TryFindSystemTimeZoneById(timeZoneId, out TimeZoneInfo? timeZone))
+        {
+            return timeZone;
+        }
+        return null;
     }
 
     public void AddLocation(Game game)

--- a/BaseballApi/ApiTests/ImportTests.cs
+++ b/BaseballApi/ApiTests/ImportTests.cs
@@ -72,6 +72,7 @@ public class ImportTests(TestImportDatabaseFixture fixture) : IClassFixture<Test
             Assert.Single(games.Value.Results);
             var gameSummary = games.Value.Results.First();
             Assert.Equal("7/8/24 St. Louis Cardinals at Washington Nationals", gameSummary.Name);
+            Assert.Equal(new DateOnly(2024, 7, 8), gameSummary.Date);
             Assert.Equal("St. Louis Cardinals", gameSummary.AwayTeamName);
             Assert.Equal("Washington Nationals", gameSummary.HomeTeamName);
             Assert.Equal(metadata.ScheduledStart, gameSummary.ScheduledTime);
@@ -95,6 +96,7 @@ public class ImportTests(TestImportDatabaseFixture fixture) : IClassFixture<Test
             Assert.NotNull(gameTask);
             var game = gameTask.Value;
             Assert.Equal("7/8/24 St. Louis Cardinals at Washington Nationals", game.Name);
+            Assert.Equal(new DateOnly(2024, 7, 8), game.Date);
             Assert.Equal("St. Louis Cardinals", game.AwayTeamName);
             Assert.Equal("Washington Nationals", game.HomeTeamName);
             Assert.Equal(metadata.ScheduledStart, game.ScheduledTime);
@@ -185,7 +187,23 @@ public class ImportTests(TestImportDatabaseFixture fixture) : IClassFixture<Test
         await ValidateTeams();
         await ValidatePlayers();
 
-        var scoreCard = newGameDetail.Scorecard;
+        // Clients send start times as UTC instants, so a night game arrives dated to the following
+        // day; the date and name should still come from the park's time zone
+        var nightScheduledTime = new DateTimeOffset(2024, 7, 8, 20, 5, 0, TimeSpan.FromHours(-4)).ToUniversalTime();
+        var nightStartTime = new DateTimeOffset(2024, 7, 8, 20, 11, 0, TimeSpan.FromHours(-4)).ToUniversalTime();
+        Assert.Equal(9, nightScheduledTime.Day);
+        metadata.ScheduledStart = nightScheduledTime;
+        metadata.ActualStart = nightStartTime;
+
+        await gamesController.ImportGame(files, JsonConvert.SerializeObject(metadata));
+
+        await remoteValidator.ValidateFileDeleted(newGameDetail.Scorecard!.Value.File);
+
+        var nightGameDetail = await ValidateGameInDb(nightStartTime);
+        await ValidateTeams();
+        await ValidatePlayers();
+
+        var scoreCard = nightGameDetail.Scorecard;
         Assert.NotNull(scoreCard);
         var scoreCardResource = await context.Scorecards.FirstOrDefaultAsync(s => s.AssetIdentifier == scoreCard.Value.File.AssetIdentifier);
         Assert.NotNull(scoreCardResource);

--- a/iScoreImport/Tests/SQLiteTests.swift
+++ b/iScoreImport/Tests/SQLiteTests.swift
@@ -112,9 +112,6 @@ final class SQLiteTests {
                 return
             }
             #expect(fullGame.ExternalId == UUID(uuidString: "8280516F-8E5F-4BD3-A96F-3620CB19751A"))
-            let dateFormatter = DateFormatter()
-            dateFormatter.dateFormat = "yyyy-MM-dd"
-            #expect(fullGame.Date == dateFormatter.date(from: "2011-08-26"))
             let datetimeFormatter = DateFormatter()
             datetimeFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
             #expect(fullGame.ScheduledTime == nil)

--- a/iScoreImport/iScoreImport/Extensions.swift
+++ b/iScoreImport/iScoreImport/Extensions.swift
@@ -7,6 +7,29 @@
 
 import Foundation
 
+extension TimeZone {
+    /// Park time zones are stored using .NET's Windows identifiers, which Foundation doesn't
+    /// recognize, so translate the ones we can before falling back to an IANA lookup.
+    init?(parkIdentifier: String) {
+        self.init(identifier: TimeZone.ianaIdentifiers[parkIdentifier] ?? parkIdentifier)
+    }
+
+    private static let ianaIdentifiers = [
+        "Eastern Standard Time": "America/New_York",
+        "Central Standard Time": "America/Chicago",
+        "Mountain Standard Time": "America/Denver",
+        "US Mountain Standard Time": "America/Phoenix",
+        "Pacific Standard Time": "America/Los_Angeles",
+        "Alaskan Standard Time": "America/Anchorage",
+        "Hawaiian Standard Time": "Pacific/Honolulu",
+        "Atlantic Standard Time": "America/Halifax",
+        "Central Standard Time (Mexico)": "America/Mexico_City",
+        "GMT Standard Time": "Europe/London",
+        "Tokyo Standard Time": "Asia/Tokyo",
+        "Korea Standard Time": "Asia/Seoul"
+    ]
+}
+
 // from https://www.swiftbysundell.com/articles/async-and-concurrent-forEach-and-map/
 extension Sequence {
     func asyncMap<T> (

--- a/iScoreImport/iScoreImport/GameImporter.swift
+++ b/iScoreImport/iScoreImport/GameImporter.swift
@@ -14,6 +14,7 @@ enum GameImportError : Error {
     case boxScoreInsertIssue(game: Game)
     case gameInsertIssue(game: Game)
     case unimportedPlayer(externalId: UUID)
+    case missingStartTime(game: Game)
 }
 
 enum GameMatchResult {
@@ -35,14 +36,20 @@ struct GameImporter {
     }
     
     func insertOrUpdateGame(game: Game) async throws {
+        guard let startTime = game.ScheduledTime ?? game.StartTime else {
+            throw GameImportError.missingStartTime(game: game)
+        }
+        // the calendar date belongs to the park, not to whatever device is running the import
+        let calendar = try await parkCalendar(team: game.HomeTeam)
+        let gameDate = calendar.startOfDay(for: startTime)
         var existingGameId: Int? = nil
         if let externalId = game.ExternalId {
             existingGameId = try await getGameId(externalId: externalId)
         }
         if existingGameId == nil {
-            let candidates = try await getGamesByDate(date: game.Date)
+            let candidates = try await getGamesByDate(date: gameDate, calendar: calendar)
             if candidates.count > 1 {
-                switch promptForGameMatch(game: game, candidates: candidates) {
+                switch promptForGameMatch(game: game, gameDate: gameDate, calendar: calendar, candidates: candidates) {
                 case .existingGame(let id):
                     existingGameId = id
                 case .insertNew:
@@ -58,14 +65,38 @@ struct GameImporter {
         }
         if let existingGameId {
             print("Updating existing")
-            try await updateGame(game: game, gameId: existingGameId)
+            try await updateGame(game: game, gameId: existingGameId, gameDate: gameDate)
         } else {
             print("Inserting new")
-            try await insertGame(game: game)
+            try await insertGame(game: game, gameDate: gameDate)
         }
     }
-    
-    private func insertGame(game: Game) async throws {
+
+    /// A calendar in the home park's time zone, falling back to the current device's zone when the
+    /// team is new or its park has no usable time zone stored.
+    private func parkCalendar(team: Team) async throws -> Calendar {
+        var calendar = Calendar.current
+        guard let city = team.City, let name = team.Name,
+              let teamId = try await teams.getTeamId(city: city, name: name),
+              let identifier = try await getParkTimeZoneIdentifier(teamId: teamId),
+              let timeZone = TimeZone(parkIdentifier: identifier) else {
+            return calendar
+        }
+        calendar.timeZone = timeZone
+        return calendar
+    }
+
+    private func getParkTimeZoneIdentifier(teamId: Int) async throws -> String? {
+        let result = try await db.select()
+            .column(SQLColumn("TimeZone", table: "Parks"))
+            .from("Parks")
+            .join("Teams", on: SQLColumn("HomeParkId", table: "Teams"), .equal, SQLColumn("Id", table: "Parks"))
+            .where(SQLColumn("Id", table: "Teams"), .equal, SQLBind(teamId))
+            .first()
+        return try? result?.decode(column: "TimeZone", as: String.self)
+    }
+
+    private func insertGame(game: Game, gameDate: Date) async throws {
         let home = try await getTeamId(team: game.HomeTeam)
         let away = try await getTeamId(team: game.AwayTeam)
         let winningTeamId = try await getOptionalTeamId(team: game.WinningTeam)
@@ -96,7 +127,7 @@ struct GameImporter {
             .values(
                 game.ExternalId ?? UUID(uuidString: "00000000-0000-0000-0000-000000000000"),
                 game.Name,
-                game.Date,
+                gameDate,
                 home,
                 away,
                 game.ScheduledTime,
@@ -123,7 +154,7 @@ struct GameImporter {
     }
 
     
-    private func updateGame(game: Game, gameId: Int) async throws {
+    private func updateGame(game: Game, gameId: Int, gameDate: Date) async throws {
         let home = try await getTeamId(team: game.HomeTeam)
         let away = try await getTeamId(team: game.AwayTeam)
         let winningTeamId = try await getOptionalTeamId(team: game.WinningTeam)
@@ -134,7 +165,7 @@ struct GameImporter {
         
         var updateStatement = db.update("Games")
             .set("Name", to: game.Name)
-            .set("Date", to: game.Date)
+            .set("Date", to: gameDate)
             .set("HomeId", to: home)
             .set("AwayId", to: away)
             .set("ScheduledTime", to: game.ScheduledTime)
@@ -370,8 +401,7 @@ struct GameImporter {
         let awayScore: Int?
     }
 
-    private func getGamesByDate(date: Date) async throws -> [GameCandidate] {
-        let calendar = Calendar.current
+    private func getGamesByDate(date: Date, calendar: Calendar) async throws -> [GameCandidate] {
         let startOfDay = calendar.startOfDay(for: date)
         let startOfNextDay = calendar.date(byAdding: .day, value: 1, to: startOfDay)!
 
@@ -394,12 +424,13 @@ struct GameImporter {
         }
     }
 
-    private func promptForGameMatch(game: Game, candidates: [GameCandidate]) -> GameMatchResult {
+    private func promptForGameMatch(game: Game, gameDate: Date, calendar: Calendar, candidates: [GameCandidate]) -> GameMatchResult {
         let dateFormatter = DateFormatter()
         dateFormatter.dateStyle = .medium
         dateFormatter.timeStyle = .none
+        dateFormatter.timeZone = calendar.timeZone
 
-        print("\nGame: \"\(game.Name)\" (\(dateFormatter.string(from: game.Date)))")
+        print("\nGame: \"\(game.Name)\" (\(dateFormatter.string(from: gameDate)))")
 
         if candidates.isEmpty {
             print("No existing games found on this date.")

--- a/iScoreImport/iScoreImport/GameImporter.swift
+++ b/iScoreImport/iScoreImport/GameImporter.swift
@@ -405,11 +405,14 @@ struct GameImporter {
         let startOfDay = calendar.startOfDay(for: date)
         let startOfNextDay = calendar.date(byAdding: .day, value: 1, to: startOfDay)!
 
+        // match on the same time the date is derived from, so that scheduled-only games and games
+        // delayed past midnight still land in the right day
+        let scheduledOrStart = SQLFunction("COALESCE", args: SQLColumn("ScheduledTime"), SQLColumn("StartTime"))
         let rows = try await db.select()
             .columns("Id", "Name", "HomeTeamName", "AwayTeamName", "HomeScore", "AwayScore")
             .from("Games")
-            .where("StartTime", .greaterThanOrEqual, startOfDay)
-            .where("StartTime", .lessThan, startOfNextDay)
+            .where(scheduledOrStart, .greaterThanOrEqual, SQLBind(startOfDay))
+            .where(scheduledOrStart, .lessThan, SQLBind(startOfNextDay))
             .all()
 
         return try rows.map { row in

--- a/iScoreImport/iScoreImport/GameLoader.swift
+++ b/iScoreImport/iScoreImport/GameLoader.swift
@@ -108,11 +108,9 @@ struct GameLoader {
         let location = Park(Name: try row.decode(column: "Location", as: String.self))
         let startTime = try decodeDatetime(row: row, colName: "StartTime")
         let scheduledTime = try decodeDatetime(row: row, colName: "ScheduledTime")
-        let dateBaseTime = scheduledTime ?? startTime
         return Game(
             Name: try row.decode(column: "Name", as: String.self),
             ExternalId: try row.decode(column: "ExternalId", as: UUID.self),
-            Date: Calendar.current.startOfDay(for: dateBaseTime!),
             HomeTeam: Team.withParsedName(team: homeTeam),
             AwayTeam: Team.withParsedName(team: awayTeam),
             ScheduledTime: scheduledTime,

--- a/iScoreImport/iScoreImport/Models/Game.swift
+++ b/iScoreImport/iScoreImport/Models/Game.swift
@@ -10,7 +10,6 @@ import Foundation
 struct Game : Codable {
     let Name: String
     let ExternalId: UUID?
-    let Date: Date
     let HomeTeam: Team
     let AwayTeam: Team
     let ScheduledTime: Date?

--- a/iScoreImport/iScoreImport/SQLiteConnector.swift
+++ b/iScoreImport/iScoreImport/SQLiteConnector.swift
@@ -57,7 +57,7 @@ struct SQLiteConnector: DbConnector {
             .all(decoding: Player.self)
     }
     
-    func getGames(afterDate: Date?) async throws -> AsyncThrowingStream<Game, Error> {
+    func getGames(afterDate: Date? = nil) async throws -> AsyncThrowingStream<Game, Error> {
         guard let db else {
             throw ConnectorError.connectionRequired
         }


### PR DESCRIPTION
Use the registered home park time zone for C# and swift imports when converting start time into a date. Fixes #153 